### PR TITLE
feat: add fuzz tests to $WM

### DIFF
--- a/test/WrappedMToken.t.sol
+++ b/test/WrappedMToken.t.sol
@@ -292,6 +292,344 @@ contract WrappedMTokenTests is Test {
         assertEq(_wrappedMToken.indexOfTotalEarningSupply(), 0);
     }
 
+    function testFuzz_onlyWrap(bool earn_, uint240 wrapAmount_) external {
+        _mToken.setBalanceOf(_alice, wrapAmount_);
+
+        if (earn_) {
+            _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+            _wrappedMToken.enableEarning();
+            _registrar.setListContains(_EARNERS_LIST, _alice, true);
+            _wrappedMToken.startEarningFor(_alice);
+        }
+
+        bool revertCond1 = wrapAmount_ == 0;
+        bool revertCond2 = earn_ && wrapAmount_ > uint256(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 2;
+
+        vm.startPrank(_alice);
+        if (revertCond1) vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, (0)));
+        else if (revertCond2) vm.expectRevert(UIntMath.InvalidUInt112.selector);
+        _wrappedMToken.wrap(_alice, wrapAmount_);
+
+        if (revertCond1 || revertCond2) return;
+
+        uint256 supply = earn_ ? _wrappedMToken.totalEarningSupply() : _wrappedMToken.totalNonEarningSupply();
+        _assertApproxEq(supply, wrapAmount_, "total earning supply");
+        _assertAndLimit(_alice, wrapAmount_, "alice balance");
+    }
+
+    function testFuzz_onlyUnwrap(bool earn_, uint240 wrapAmount_, uint240 unWrapAmount_) external {
+        wrapAmount_ = wrapAmount_ % (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 3);
+
+        if (earn_) {
+            _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+            _wrappedMToken.enableEarning();
+            _registrar.setListContains(_EARNERS_LIST, _alice, true);
+            _wrappedMToken.startEarningFor(_alice);
+        }
+
+        if (wrapAmount_ > 0) {
+            _mToken.setBalanceOf(address(_alice), wrapAmount_);
+            vm.prank(_alice);
+            _wrappedMToken.wrap(_alice, wrapAmount_);
+        }
+
+        bool revertCond1 = unWrapAmount_ == 0;
+        bool revertCond2 = unWrapAmount_ > _wrappedMToken.balanceOf(_alice);
+
+        if (revertCond1) vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, 0));
+        else if (revertCond2) 
+            vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.InsufficientBalance.selector, 
+                _alice, _wrappedMToken.balanceOf(_alice), unWrapAmount_));
+
+        vm.prank(_alice);
+        _wrappedMToken.unwrap(_alice, unWrapAmount_);
+
+        if (revertCond1 || revertCond2) return;
+        
+        uint256 supply_ = earn_ ? _wrappedMToken.totalEarningSupply() : _wrappedMToken.totalNonEarningSupply();
+        _assertApproxEqRatio(supply_, wrapAmount_ - unWrapAmount_, "total earning supply");
+        _assertAndLimit(_alice, wrapAmount_ - unWrapAmount_, "alice balance");
+    }
+
+    function testFuzz_onlyTransfer(
+        bool aliceEarn_, 
+        bool bobEarn_, 
+        uint240 aliceAmount_, 
+        uint240 bobAmount_, 
+        uint240 transferAmount_
+    ) external {
+        uint240 maxAmount_ = (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 1);
+        aliceAmount_ = aliceAmount_ % (maxAmount_ + 1);
+        bobAmount_ = bobAmount_ % (maxAmount_ + 1);
+        transferAmount_ = transferAmount_ % (maxAmount_ + 1);
+
+        _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+        _wrappedMToken.enableEarning();
+
+        if (aliceEarn_) {
+            _registrar.setListContains(_EARNERS_LIST, _alice, true);
+            _wrappedMToken.startEarningFor(_alice);
+        }
+        if (bobEarn_) {
+            _registrar.setListContains(_EARNERS_LIST, _bob, true);
+            _wrappedMToken.startEarningFor(_bob);
+        }
+
+        if (aliceAmount_ > 0) {
+            _mToken.setBalanceOf(address(_alice), aliceAmount_);
+            vm.prank(_alice);
+            _wrappedMToken.wrap(_alice, aliceAmount_);
+        }
+
+        if (bobAmount_ > 0) {
+            _mToken.setBalanceOf(address(_bob), bobAmount_);
+            vm.prank(_bob);
+            _wrappedMToken.wrap(_bob, bobAmount_);
+        }
+
+        bool revertCond1 = transferAmount_ > _wrappedMToken.balanceOf(_alice);
+        bool revertCond2 = bobEarn_ && bobAmount_ + transferAmount_ > maxAmount_ + 1;
+
+        if (revertCond1) 
+            vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.InsufficientBalance.selector, 
+                _alice, _wrappedMToken.balanceOf(_alice), transferAmount_));
+        else if (revertCond2) vm.expectRevert(UIntMath.InvalidUInt112.selector);
+
+        vm.prank(_alice);        
+        _wrappedMToken.transfer(_bob, transferAmount_);
+
+        if (revertCond1 || revertCond2) return;
+
+        _assertAndLimit(_alice, aliceAmount_ - transferAmount_, "alice balance");
+        _assertAndLimit(_bob, bobAmount_ + transferAmount_, "bob balance");
+
+        uint256 earningSupply_ = _wrappedMToken.totalEarningSupply();
+        uint256 bobEarningSupply_ = bobEarn_ ? bobAmount_ + transferAmount_ : 0;
+        uint256 aliceEarningSupply_ = aliceEarn_ ? aliceAmount_ - transferAmount_ : 0;
+        _assertApproxEqRatio(earningSupply_, bobEarningSupply_ + aliceEarningSupply_, "earning supply");
+        uint256 nonEarningSupply_ = _wrappedMToken.totalNonEarningSupply();
+        uint256 bobNonEarningSupply_ = bobEarn_ ? 0 : bobAmount_ + transferAmount_;
+        uint256 aliceNonEarningSupply_ = aliceEarn_ ? 0 : aliceAmount_ - transferAmount_;
+        _assertApproxEqRatio(nonEarningSupply_, bobNonEarningSupply_ + aliceNonEarningSupply_, "non earning supply");
+    }
+
+    function testFuzz_onlyStartEarningFor(uint240 wrapAmount_) external {
+        wrapAmount_ = wrapAmount_ % (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 3);
+        
+        _mToken.setBalanceOf(address(_alice), wrapAmount_);
+        vm.prank(_alice);
+        if (wrapAmount_ > 0) _wrappedMToken.wrap(_alice, wrapAmount_);
+
+        _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+        _wrappedMToken.enableEarning();
+        _registrar.setListContains(_EARNERS_LIST, _alice, true);
+        _wrappedMToken.startEarningFor(_alice);
+
+        _assertAndLimit(_alice, wrapAmount_, "alice balance");
+
+        _assertApproxEq(_wrappedMToken.totalEarningSupply(), wrapAmount_, "earning supply");
+        assertEq(_wrappedMToken.totalNonEarningSupply(), 0);
+    }
+
+    function testFuzz_onlyStopEarningFor(uint240 wrapAmount_) external {
+        wrapAmount_ = wrapAmount_ % (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 3);
+
+        _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+        _wrappedMToken.enableEarning();
+        _registrar.setListContains(_EARNERS_LIST, _alice, true);
+        _wrappedMToken.startEarningFor(_alice);
+        
+        _mToken.setBalanceOf(address(_wrappedMToken), wrapAmount_);
+        _wrappedMToken.setAccountOf(_alice, true, _currentIndex, wrapAmount_);
+
+        _registrar.setListContains(_EARNERS_LIST, _alice, false);
+        _wrappedMToken.stopEarningFor(_alice);
+
+        _assertAndLimit(_alice, wrapAmount_, "alice balance");
+
+        _assertApproxEq(_wrappedMToken.totalNonEarningSupply(), wrapAmount_, "earning supply");
+        assertEq(_wrappedMToken.totalEarningSupply(), 0);
+    }
+
+    function testFuzz_claimFor(uint240 wrapAmount_, uint128 idxIncrease_) external {
+        wrapAmount_ = wrapAmount_ % (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 3);
+
+        _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+        _wrappedMToken.enableEarning();
+        _registrar.setListContains(_EARNERS_LIST, _alice, true);
+        _wrappedMToken.startEarningFor(_alice);
+        
+        _mToken.setBalanceOf(address(_alice), wrapAmount_);
+        vm.prank(_alice);
+        if (wrapAmount_ > 0) _wrappedMToken.wrap(_alice, wrapAmount_);
+
+        uint128 newIndex_ = _currentIndex + idxIncrease_ % _EXP_SCALED_ONE;
+        _mToken.setCurrentIndex(newIndex_);
+
+        uint256 newBalance_ = wrapAmount_ * newIndex_ / _currentIndex;
+
+        _assertAndLimit(_alice, newBalance_, "alice balance");
+
+        _assertApproxEq(_wrappedMToken.totalEarningSupply(), newBalance_, "total earning supply");
+    }
+
+    function testFuzz_claimExcess(uint240 aliceWrapAmount_, uint240 bobWrapAmount_, uint128 idxIncrease_) external {
+        aliceWrapAmount_ = aliceWrapAmount_ % (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 3);
+        bobWrapAmount_ = bobWrapAmount_ % (uint240(type(uint112).max) * _currentIndex / _EXP_SCALED_ONE + 3);
+        uint128 newIndex_ = _currentIndex + idxIncrease_ % _EXP_SCALED_ONE;
+        
+        _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+        _wrappedMToken.enableEarning();
+        _registrar.setListContains(_EARNERS_LIST, _alice, true);
+        _wrappedMToken.startEarningFor(_alice);
+        
+        _mToken.setBalanceOf(_alice, aliceWrapAmount_);
+        vm.prank(_alice);
+        if (aliceWrapAmount_ > 0) _wrappedMToken.wrap(_alice, aliceWrapAmount_);
+        vm.stopPrank();
+
+        _mToken.setBalanceOf(_bob, bobWrapAmount_);
+        vm.prank(_bob);
+        if (bobWrapAmount_ > 0) _wrappedMToken.wrap(_bob, bobWrapAmount_);
+
+        _mToken.setBalanceOf(address(_wrappedMToken), (aliceWrapAmount_ + bobWrapAmount_) * newIndex_ / _currentIndex);
+        _mToken.setCurrentIndex(newIndex_);
+
+        _wrappedMToken.claimExcess();
+        uint256 expectedBalance_ = bobWrapAmount_ * newIndex_ / _currentIndex - bobWrapAmount_;
+
+        _assertApproxEq(_mToken.balanceOf(_vault), expectedBalance_, "vault");
+
+        _assertApproxEq(_wrappedMToken.totalNonEarningSupply(), bobWrapAmount_, "earning supply");
+        _assertApproxEq(_wrappedMToken.totalEarningSupply(), aliceWrapAmount_, "non earning supply");
+    }
+
+    struct TestData {
+        uint256 aliceWrap1;
+        uint256 aliceWrap2;
+        uint256 bobWrap1;
+        uint256 bobWrap2;
+        uint256 aliceTransfer;
+        uint256 bobUnwrap;
+        bool aliceIsEarning;
+        bool bobIsEarning;
+        uint128[7] mTokenIdx;
+    }
+
+    function testFuzz_wrap_transfer_unwrap(TestData memory data_) external {
+        _registrar.setListContains(_EARNERS_LIST, address(_wrappedMToken), true);
+        _registrar.setListContains(_EARNERS_LIST, _alice, true);
+        _registrar.setListContains(_EARNERS_LIST, _bob, true);
+        _wrappedMToken.enableEarning();
+
+        data_.aliceWrap1 = data_.aliceWrap1 % 1_000e6;
+        data_.aliceWrap2 = data_.aliceWrap2 % 1_000e6;
+        data_.bobWrap1 = data_.bobWrap1 % 1_000e6;
+        data_.bobWrap2 = data_.bobWrap2 % 1_000e6;
+
+        uint128[8] memory mTokenIdx_;
+        mTokenIdx_[0] = _currentIndex;
+        for (uint i = 0; i < 7; i++) {
+            data_.mTokenIdx[i] = data_.mTokenIdx[i] % _EXP_SCALED_ONE;
+            mTokenIdx_[i + 1] = mTokenIdx_[i] + data_.mTokenIdx[i];
+        }
+
+        _mToken.setBalanceOf(_alice, data_.aliceWrap1 + data_.aliceWrap2);
+        _mToken.setBalanceOf(_bob, data_.bobWrap1 + data_.bobWrap2);
+        uint256 totalMBalance = data_.aliceWrap1 + data_.aliceWrap2 + data_.bobWrap1 + data_.bobWrap2;
+        _mToken.setBalanceOf(address(_wrappedMToken), totalMBalance * mTokenIdx_[7] / mTokenIdx_[0]);
+
+        if (data_.aliceIsEarning) _wrappedMToken.startEarningFor(_alice);
+
+        vm.prank(_alice);
+        if (data_.aliceWrap1 != 0) _wrappedMToken.wrap(_alice, data_.aliceWrap1);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[0]);
+        
+        vm.prank(_bob);
+        if (data_.bobWrap1 != 0) _wrappedMToken.wrap(_bob, data_.bobWrap1);
+        
+        if (data_.bobIsEarning) _wrappedMToken.startEarningFor(_bob);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[1]);
+
+        vm.prank(_bob);
+        if (data_.bobWrap2 != 0) _wrappedMToken.wrap(_bob, data_.bobWrap2);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[2]);
+
+        vm.prank(_alice);
+        if (data_.aliceWrap2 != 0) _wrappedMToken.wrap(_alice, data_.aliceWrap2);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[3]);
+
+        uint256 aliceBalance_ = data_.aliceIsEarning
+            ? data_.aliceWrap1 * mTokenIdx_[4] / mTokenIdx_[0] + data_.aliceWrap2 * mTokenIdx_[4] / mTokenIdx_[3]
+            : data_.aliceWrap1 + data_.aliceWrap2;
+        aliceBalance_ = _assertAndLimit(_alice, aliceBalance_, "alice balance");
+        uint256 firstAliceTransfer_ = data_.aliceTransfer % (aliceBalance_ + 1);
+        vm.prank(_alice);
+        _wrappedMToken.transfer(_bob, firstAliceTransfer_);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[4]);
+
+        uint256 aliceBalanceLeft_ = aliceBalance_ - firstAliceTransfer_;
+        if (data_.aliceIsEarning) aliceBalanceLeft_ = aliceBalanceLeft_ * mTokenIdx_[5] / mTokenIdx_[4];
+        aliceBalanceLeft_ = _assertAndLimit(_alice, aliceBalanceLeft_, "alice remaining balance");
+        vm.prank(_alice);
+        _wrappedMToken.transfer(_bob, aliceBalanceLeft_);
+        assertEq(_wrappedMToken.balanceOf(_alice), 0);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[5]);
+
+        uint256 bobBalance_ = data_.aliceIsEarning 
+            ? aliceBalance_ * mTokenIdx_[6] / mTokenIdx_[4] 
+            : firstAliceTransfer_ * mTokenIdx_[6] / mTokenIdx_[4] + aliceBalanceLeft_ * mTokenIdx_[6] / mTokenIdx_[5];
+        if (!data_.bobIsEarning) bobBalance_ = firstAliceTransfer_ + aliceBalanceLeft_;
+
+        bobBalance_ += data_.bobIsEarning 
+            ? data_.bobWrap1 * mTokenIdx_[6] / mTokenIdx_[1] + data_.bobWrap2 * mTokenIdx_[6] / mTokenIdx_[2]
+            : data_.bobWrap1 + data_.bobWrap2;
+        
+        bobBalance_ = _assertAndLimit(_bob, bobBalance_, "bob balance");
+
+        uint256 firstBobUnwrap_ = data_.bobUnwrap % (bobBalance_ + 1);
+        vm.prank(_bob);
+        if (firstBobUnwrap_ == 0) vm.expectRevert(); 
+        _wrappedMToken.unwrap(_bob, firstBobUnwrap_);
+
+        _mToken.setCurrentIndex(_currentIndex = _currentIndex + data_.mTokenIdx[6]);
+
+        bobBalance_ = bobBalance_ - firstBobUnwrap_;
+        if (data_.bobIsEarning) bobBalance_ = bobBalance_ * mTokenIdx_[7] / mTokenIdx_[6];
+        bobBalance_ = _assertAndLimit(_bob, bobBalance_, "bob remaining balance");
+
+        vm.prank(_bob);
+        if (bobBalance_ == 0) vm.expectRevert();
+        _wrappedMToken.unwrap(_bob, bobBalance_);
+        assertEq(_wrappedMToken.balanceOf(_bob), 0);
+
+        _assertApproxEq(_wrappedMToken.totalEarningSupply(), 0, "totalEarningSupply");
+        _assertApproxEq(_wrappedMToken.totalNonEarningSupply(), 0, "totalNonEarningSupply");
+    }
+
+    function _assertAndLimit(address user_, uint256 expectedBalance_, string memory step_) internal returns(uint256) {
+        _wrappedMToken.claimFor(user_);
+        uint256 realBalance_ = _wrappedMToken.balanceOf(user_);
+        _assertApproxEq(realBalance_, expectedBalance_, step_);
+        return _wrappedMToken.balanceOf(user_);
+    }
+
+    function _assertApproxEq(uint256 a, uint256 b, string memory message) internal pure {
+        assertGe(a + 100, b, string.concat(message, " not greater"));
+        assertGe(b + 100, a, string.concat(message, " not smaller"));
+    }
+
+    function _assertApproxEqRatio(uint256 a, uint256 b, string memory message) internal pure {
+        assertGe(a, b * 99999 / 1e6, string.concat(message, " not greater"));
+        assertGe(b, a * 99999 / 1e6, string.concat(message, " not smaller"));
+    }
+
     function testFuzz_transfer_fromNonEarner_toNonEarner(
         uint256 supply_,
         uint256 aliceBalance_,

--- a/test/integration/UniswapV3.t.sol
+++ b/test/integration/UniswapV3.t.sol
@@ -168,14 +168,16 @@ contract UniswapV3IntegrationTests is TestBase {
 
     function testFuzz_uniswapV3_earning(uint256 wmAlice_, uint256 bobUsdc_, uint256 wmDave_) public {
         wmAlice_ = bound(wmAlice_, 1, type(uint256).max); // Uniswap fails for 0 amounts
-        wmAlice_ = wmAlice_ % _mToken.balanceOf(_mSource);
+        bobUsdc_ = bound(bobUsdc_, 1, type(uint256).max);
+        wmDave_ = bound(wmAlice_, 1, type(uint256).max);
+
+        wmAlice_ = wmAlice_ % (_mToken.balanceOf(_mSource) - 2e5);
         bobUsdc_ = bobUsdc_ % 1e12;
 
         _giveM(_alice, wmAlice_ + 1e5);
         _wrap(_alice, _alice, wmAlice_ + 1e5);
-
-        wmDave_ = bound(wmAlice_, 1, type(uint256).max);
-        wmDave_ = wmDave_ % (_mToken.balanceOf(_mSource));
+        
+        wmDave_ = wmDave_ % (_mToken.balanceOf(_mSource) - 1e5);
 
         deal(_USDC, _alice, wmAlice_ + 1e5);
 


### PR DESCRIPTION
Fuzz tests to most $WM functionality. Also includes fuzz tests for Uniswap integration.
Currently some tests revert due to trying to transfer more balance than the user has, such as `testFuzz_onlyTransfer()`. This happens because it rounds up the principal and then the present amount, which proves to be too much in some cases.
Uniswap sometimes also reverts with the `IIA` error, [here](https://github.com/Uniswap/v3-core/blob/main/contracts/UniswapV3Pool.sol#L777).