### PR TITLE
Kirill's audit suggestion

### DIFF
--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -567,8 +567,19 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     function _unwrap(address account_, address recipient_, uint240 amount_) internal {
         _burn(account_, amount_);
 
+        uint128 currentIndex_ = currentIndex();
+
+        // NOTE: Round down the M amount that `recipient_` will receive in favor of protocol,
+        //       applicable only if Wrapped M is earning yield
+        uint240 transferAmount_ = isEarningEnabled()
+            ? IndexingMath.getPresentAmountRoundedDown(
+                IndexingMath.getPrincipalAmountRoundedDown(amount_, currentIndex_),
+                currentIndex_
+            )
+            : amount_;
+
         // NOTE: The behavior of `IMTokenLike.transfer` is known, so its return can be ignored.
-        IMTokenLike(mToken).transfer(recipient_, amount_);
+        IMTokenLike(mToken).transfer(recipient_, transferAmount_);
     }
 
     /* ============ Internal View/Pure Functions ============ */

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -569,8 +569,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
 
         uint128 currentIndex_ = currentIndex();
 
-        // NOTE: Round down the M amount that `recipient_` will receive in favor of protocol,
-        //       applicable only if Wrapped M is earning yield
+        // If the wrapper is an M earner, adjust the transfer amount to ensure the decrement of it's M balance is limited to `amount_`.
         uint240 transferAmount_ = isEarningEnabled()
             ? IndexingMath.getPresentAmountRoundedDown(
                 IndexingMath.getPrincipalAmountRoundedDown(amount_, currentIndex_),

--- a/test/Stories.t.sol
+++ b/test/Stories.t.sol
@@ -311,7 +311,7 @@ contract Tests is Test {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 50_000000);
         assertEq(_wrappedMToken.totalSupply(), 450_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), 183_333335);
-        assertEq(_wrappedMToken.excess(), 600_000001);
+        assertEq(_wrappedMToken.excess(), 600_000005);
 
         vm.prank(_bob);
         _wrappedMToken.unwrap(_bob, 333_333330);
@@ -325,7 +325,7 @@ contract Tests is Test {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 50_000000);
         assertEq(_wrappedMToken.totalSupply(), 250_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), 50_000005);
-        assertEq(_wrappedMToken.excess(), 600_000001);
+        assertEq(_wrappedMToken.excess(), 600_000005);
 
         vm.prank(_carol);
         _wrappedMToken.unwrap(_carol, 250_000000);
@@ -339,7 +339,7 @@ contract Tests is Test {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 50_000000);
         assertEq(_wrappedMToken.totalSupply(), 50_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), 0);
-        assertEq(_wrappedMToken.excess(), 600_000006);
+        assertEq(_wrappedMToken.excess(), 600_000010);
 
         vm.prank(_dave);
         _wrappedMToken.unwrap(_dave, 50_000000);
@@ -353,7 +353,7 @@ contract Tests is Test {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 0);
         assertEq(_wrappedMToken.totalSupply(), 0);
         assertEq(_wrappedMToken.totalAccruedYield(), 0);
-        assertEq(_wrappedMToken.excess(), 600_000006);
+        assertEq(_wrappedMToken.excess(), 600_000010);
 
         _wrappedMToken.claimExcess();
 

--- a/test/integration/Protocol.t.sol
+++ b/test/integration/Protocol.t.sol
@@ -476,7 +476,7 @@ contract ProtocolIntegrationTests is TestBase {
         _unwrap(_alice, _alice, _aliceBalance);
 
         // Assert Alice (Non-Earner)
-        assertEq(_mToken.balanceOf(_alice), _aliceBalance);
+        assertEq(_mToken.balanceOf(_alice), _aliceBalance - 1);
         assertEq(_wrappedMToken.balanceOf(_alice), _aliceBalance -= _aliceBalance);
         assertEq(_wrappedMToken.accruedYieldOf(_alice), _aliceAccruedYield);
 
@@ -485,7 +485,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 99_999999);
         assertEq(_wrappedMToken.totalSupply(), 299_999998);
         assertEq(_wrappedMToken.totalAccruedYield(), 6_264284);
-        assertEq(_wrappedMToken.excess(), _excess -= 1);
+        assertEq(_wrappedMToken.excess(), _excess);
 
         assertGe(
             _wrapperBalanceOfM = _mToken.balanceOf(address(_wrappedMToken)),
@@ -496,7 +496,7 @@ contract ProtocolIntegrationTests is TestBase {
         _unwrap(_bob, _bob, _bobBalance + _bobAccruedYield);
 
         // Assert Bob (Earner)
-        assertEq(_mToken.balanceOf(_bob), _bobBalance + _bobAccruedYield);
+        assertEq(_mToken.balanceOf(_bob), _bobBalance + _bobAccruedYield - 1);
         assertEq(_wrappedMToken.balanceOf(_bob), _bobBalance -= _bobBalance);
         assertEq(_wrappedMToken.accruedYieldOf(_bob), _bobAccruedYield -= _bobAccruedYield);
 
@@ -505,7 +505,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 99_999999);
         assertEq(_wrappedMToken.totalSupply(), 199_999999);
         assertEq(_wrappedMToken.totalAccruedYield(), 2_496406);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             _wrapperBalanceOfM = _mToken.balanceOf(address(_wrappedMToken)),
@@ -516,7 +516,7 @@ contract ProtocolIntegrationTests is TestBase {
         _unwrap(_carol, _carol, _carolBalance + _carolAccruedYield);
 
         // Assert Carol (Earner)
-        assertEq(_mToken.balanceOf(_carol), _carolBalance + _carolAccruedYield);
+        assertEq(_mToken.balanceOf(_carol), _carolBalance + _carolAccruedYield - 1);
         assertEq(_wrappedMToken.balanceOf(_carol), _carolBalance -= _carolBalance);
         assertEq(_wrappedMToken.accruedYieldOf(_carol), _carolAccruedYield -= _carolAccruedYield);
 
@@ -525,14 +525,14 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 99_999999);
         assertEq(_wrappedMToken.totalSupply(), 99_999999);
         assertEq(_wrappedMToken.totalAccruedYield(), 0);
-        assertEq(_wrappedMToken.excess(), _excess += 2);
+        assertEq(_wrappedMToken.excess(), _excess += 3);
 
         assertGe(_wrapperBalanceOfM = _mToken.balanceOf(address(_wrappedMToken)), _daveBalance + _excess);
 
         _unwrap(_dave, _dave, _daveBalance);
 
         // Assert Dave (Non-Earner)
-        assertEq(_mToken.balanceOf(_dave), _daveBalance);
+        assertEq(_mToken.balanceOf(_dave), _daveBalance - 1);
         assertEq(_wrappedMToken.balanceOf(_dave), _daveBalance -= _daveBalance);
         assertEq(_wrappedMToken.accruedYieldOf(_dave), 0);
 
@@ -541,13 +541,13 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 0);
         assertEq(_wrappedMToken.totalSupply(), 0);
         assertEq(_wrappedMToken.totalAccruedYield(), 0);
-        assertEq(_wrappedMToken.excess(), _excess);
+        assertEq(_wrappedMToken.excess(), _excess + 1);
 
         assertGe(_wrapperBalanceOfM = _mToken.balanceOf(address(_wrappedMToken)), _excess);
 
         uint256 vaultStartingBalance_ = _mToken.balanceOf(_vault);
 
-        assertEq(_wrappedMToken.claimExcess(), _excess);
+        assertEq(_wrappedMToken.claimExcess(), _excess += 1);
         assertEq(_mToken.balanceOf(_vault), _excess + vaultStartingBalance_);
 
         // Assert Globals
@@ -555,7 +555,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), 0);
         assertEq(_wrappedMToken.totalSupply(), 0);
         assertEq(_wrappedMToken.totalAccruedYield(), 0);
-        assertEq(_wrappedMToken.excess(), _excess -= _excess);
+        assertEq(_wrappedMToken.excess(), 0);
 
         assertGe(_wrapperBalanceOfM = _mToken.balanceOf(address(_wrappedMToken)), 0);
     }


### PR DESCRIPTION
Make `unwrap` symmetric to `wrap`, round in favor of protocol.