### PR TITLE
feat: remove `getSafeTransferableM`

### DIFF
--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -87,7 +87,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     uint112 public totalEarningPrincipal;
 
     /// @inheritdoc IWrappedMToken
-    int144 public roundingError;
+    uint144 public roundingError;
 
     /// @inheritdoc IWrappedMToken
     uint240 public totalEarningSupply;
@@ -187,9 +187,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
 
         if (excess_ <= 0) revert NoExcess();
 
-        claimed_ = _getSafeTransferableM(address(this), uint240(uint248(excess_)));
-
-        emit ExcessClaimed(claimed_);
+        emit ExcessClaimed(claimed_ = uint240(uint248(excess_)));
 
         // NOTE: The behavior of `IMTokenLike.transfer` is known, so its return can be ignored.
         IMTokenLike(mToken).transfer(excessDestination, claimed_);
@@ -342,11 +340,12 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     /// @inheritdoc IWrappedMToken
     function excess() public view returns (int248 excess_) {
         unchecked {
-            int248 earmarked_ = int248(uint248(totalNonEarningSupply + projectedEarningSupply())) + roundingError;
-            int248 balance_ = int248(uint248(_mBalanceOf(address(this))));
+            uint240 earmarked_ = totalNonEarningSupply + projectedEarningSupply() + roundingError;
+            uint240 balance_ = _mBalanceOf(address(this));
 
-            // The entire M balance is excess if the total projected supply (factoring rounding errors) is less than 0.
-            return earmarked_ <= 0 ? balance_ : balance_ - earmarked_;
+            // The entire M balance is excess if the total projected supply (factoring rounding errors) is 0.
+            return
+                earmarked_ == 0 ? int248(uint248(balance_)) : int248(uint248(balance_)) - int248(uint248(earmarked_));
         }
     }
 
@@ -694,7 +693,23 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
      * @return wrapped_   The amount of wM minted.
      */
     function _wrap(address account_, address recipient_, uint240 amount_) internal returns (uint240 wrapped_) {
-        _transferFromM(account_, amount_);
+        uint240 startingBalance_ = _mBalanceOf(address(this));
+
+        // NOTE: The behavior of `IMTokenLike.transferFrom` is known, so its return can be ignored.
+        IMTokenLike(mToken).transferFrom(account_, address(this), amount_);
+
+        // NOTE: When this WrappedMToken contract is earning, any amount of M sent to it is converted to a principal
+        //       amount at the MToken contract, which when represented as a present amount, may be a rounding error
+        //       amount more/less than `amount_`. In order to capture the real increase in M, the difference between the
+        //       starting and ending M balance is captured.
+        uint240 increase_ = _mBalanceOf(address(this)) - startingBalance_;
+
+        // `recipient_` gets at least as much wM as `amount_`, or more if `increase_ > amount_`.
+        if (increase_ < amount_) {
+            // If the M gained is less than the wM to be minted, then the difference is added to `roundingError`.
+            roundingError += uint144(amount_ - increase_);
+        }
+
         _mint(recipient_, wrapped_ = amount_);
     }
 
@@ -706,8 +721,21 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
      * @return unwrapped_ The amount of M withdrawn.
      */
     function _unwrap(address account_, address recipient_, uint240 amount_) internal returns (uint240 unwrapped_) {
-        _burn(account_, amount_);
-        _transferM(recipient_, unwrapped_ = amount_);
+        _burn(account_, unwrapped_ = amount_);
+
+        uint240 startingBalance_ = _mBalanceOf(address(this));
+
+        // NOTE: The behavior of `IMTokenLike.transfer` is known, so its return can be ignored.
+        IMTokenLike(mToken).transfer(recipient_, amount_);
+
+        // NOTE: When this WrappedMToken contract is earning, any amount of M sent from it is converted to a principal
+        //       amount at the MToken contract, which when represented as a present amount, may be a rounding error
+        //       amount more than `amount_`. In order to capture the real decrease in M, the difference between the
+        //       ending and starting M balance is captured.
+        uint240 decrease_ = startingBalance_ - _mBalanceOf(address(this));
+
+        // If the M lost is more than the wM burned, then the difference is added to `roundingError`.
+        roundingError += uint144(decrease_ - amount_);
     }
 
     /**
@@ -772,48 +800,6 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
         emit StoppedEarning(account_);
     }
 
-    /**
-     * @dev   Transfer `amount_` M to `recipient_`, tracking this contract's M balance rounding errors.
-     * @param recipient_ The account to transfer M to.
-     * @param amount_    The amount of M to transfer.
-     */
-    function _transferM(address recipient_, uint240 amount_) internal {
-        uint240 startingBalance_ = _mBalanceOf(address(this));
-
-        // NOTE: The behavior of `IMTokenLike.transfer` is known, so its return can be ignored.
-        IMTokenLike(mToken).transfer(recipient_, amount_);
-
-        // NOTE: When this WrappedMToken contract is earning, any amount of M sent from it is converted to a principal
-        //       amount at the MToken contract, which when represented as a present amount, may be a rounding error
-        //       amount more than `amount_`. In order to capture the real decrease in M, the difference between the
-        //       ending and starting M balance is captured.
-        uint240 decrease_ = startingBalance_ - _mBalanceOf(address(this));
-
-        // If the M lost is more than the wM burned, then the difference is added to `roundingError`.
-        roundingError += int144(int256(uint256(decrease_)) - int256(uint256(amount_)));
-    }
-
-    /**
-     * @dev   Transfer `amount_` M from `sender_`, tracking this contract's M balance rounding errors.
-     * @param sender_ The account to transfer M from.
-     * @param amount_ The amount of M to transfer.
-     */
-    function _transferFromM(address sender_, uint240 amount_) internal {
-        uint240 startingBalance_ = _mBalanceOf(address(this));
-
-        // NOTE: The behavior of `IMTokenLike.transferFrom` is known, so its return can be ignored.
-        IMTokenLike(mToken).transferFrom(sender_, address(this), _getSafeTransferableM(sender_, amount_));
-
-        // NOTE: When this WrappedMToken contract is earning, any amount of M sent to it is converted to a principal
-        //       amount at the MToken contract, which when represented as a present amount, may be a rounding error
-        //       amount more/less than `amount_`. In order to capture the real increase in M, the difference between the
-        //       starting and ending M balance is captured.
-        uint240 increase_ = _mBalanceOf(address(this)) - startingBalance_;
-
-        // If the M gained is more/less than the wM minted, then the difference is subtracted/added to `roundingError`.
-        roundingError += int144(int256(uint256(amount_)) - int256(uint256(increase_)));
-    }
-
     /* ============ Internal View/Pure Functions ============ */
 
     /// @dev Returns the current index of the M Token.
@@ -872,30 +858,6 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
      */
     function _getFromRegistrar(bytes32 key_) internal view returns (bytes32 value_) {
         return IRegistrarLike(registrar).get(key_);
-    }
-
-    /**
-     * @dev    Compute the adjusted amount of M that can safely be transferred out given the current index.
-     * @param  amount_     Some amount to be transferred out of this contract.
-     * @return safeAmount_ The adjusted amount that can safely be transferred out.
-     */
-    function _getSafeTransferableM(address sender_, uint240 amount_) internal view returns (uint240 safeAmount_) {
-        // If `sender` is not earning, no need to adjust `amount_`.
-        if (!IMTokenLike(mToken).isEarning(sender_)) return amount_;
-
-        uint128 currentIndex_ = _currentMIndex();
-        uint112 startingPrincipal_ = uint112(IMTokenLike(mToken).principalBalanceOf(sender_));
-        uint240 startingBalance_ = IndexingMath.getPresentAmountRoundedDown(startingPrincipal_, currentIndex_);
-
-        // Adjust `amount_` to ensure it's M balance decrement is limited to `amount_`.
-        unchecked {
-            uint112 minEndingPrincipal_ = IndexingMath.getPrincipalAmountRoundedUp(
-                startingBalance_ - amount_,
-                currentIndex_
-            );
-
-            return IndexingMath.getPresentAmountRoundedDown(startingPrincipal_ - minEndingPrincipal_, currentIndex_);
-        }
     }
 
     /// @dev Returns the address of the contract to use as a migrator, if any.

--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -326,6 +326,6 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
     /// @notice The address of the destination where excess is claimed to.
     function excessDestination() external view returns (address excessDestination);
 
-    /// @notice The amount of rounding error the contract has lost due to rounding in favour of users.
-    function roundingError() external view returns (int144 roundingError);
+    /// @notice The amount of M the contract has lost due to rounding in favour of users.
+    function roundingError() external view returns (uint144 roundingError);
 }

--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -325,7 +325,4 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
 
     /// @notice The address of the destination where excess is claimed to.
     function excessDestination() external view returns (address excessDestination);
-
-    /// @notice The amount of M the contract has lost due to rounding in favour of users.
-    function roundingError() external view returns (uint144 roundingError);
 }

--- a/test/integration/Protocol.t.sol
+++ b/test/integration/Protocol.t.sol
@@ -608,14 +608,15 @@ contract ProtocolIntegrationTests is TestBase {
 
         uint256 vaultStartingBalance_ = _mToken.balanceOf(_excessDestination);
 
-        assertEq(_wrappedMToken.claimExcess(), uint256(_excess - 1));
-        assertEq(_mToken.balanceOf(_excessDestination), uint256(_excess - 1) + vaultStartingBalance_);
+        assertEq(_wrappedMToken.claimExcess(), uint256(_excess));
+
+        assertEq(_mToken.balanceOf(_excessDestination), uint256(_excess) + vaultStartingBalance_);
 
         // Assert Globals
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= _excess);
+        assertEq(_wrappedMToken.excess(), _excess -= _excess + 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -624,17 +625,19 @@ contract ProtocolIntegrationTests is TestBase {
     }
 
     function testFuzz_full(uint256 seed_) external {
-        // TODO: Reinstate to test post-migration for new version.
         vm.skip(true);
+
+        _wrappedMToken.claimExcess();
 
         for (uint256 index_; index_ < _accounts.length; ++index_) {
             _giveM(_accounts[index_], 100_000e6);
         }
 
-        for (uint256 index_; index_ < 1000; ++index_) {
-            assertTrue(Invariants.checkInvariant1(address(_wrappedMToken), _accounts), "Invariant 1 Failed.");
-            assertTrue(Invariants.checkInvariant2(address(_wrappedMToken), _accounts), "Invariant 2 Failed.");
-            assertTrue(Invariants.checkInvariant4(address(_wrappedMToken), _accounts), "Invariant 4 Failed.");
+        for (uint256 index_; index_ < 1_000; ++index_) {
+            // assertTrue(Invariants.checkInvariant1(address(_wrappedMToken), _accounts), "Invariant 1 Failed.");
+            // assertTrue(Invariants.checkInvariant2(address(_wrappedMToken), _accounts), "Invariant 2 Failed.");
+            assertTrue(Invariants.checkInvariant3(address(_wrappedMToken), address(_mToken)), "Invariant 3 Failed.");
+            // assertTrue(Invariants.checkInvariant4(address(_wrappedMToken), _accounts), "Invariant 4 Failed.");
 
             // console2.log("--------");
             // console2.log("");
@@ -648,12 +651,10 @@ contract ProtocolIntegrationTests is TestBase {
             // console2.log("");
             // console2.log("--------");
 
-            assertTrue(Invariants.checkInvariant1(address(_wrappedMToken), _accounts), "Invariant 1 Failed.");
-            assertTrue(Invariants.checkInvariant2(address(_wrappedMToken), _accounts), "Invariant 2 Failed.");
-            assertTrue(Invariants.checkInvariant4(address(_wrappedMToken), _accounts), "Invariant 4 Failed.");
-
-            // NOTE: Skipping this as there is no trivial way to guarantee this invariant while meeting 1 and 2.
-            // assertTrue(Invariants.checkInvariant3(address(_wrappedMToken), address(_mToken)), "Invariant 3 Failed.");
+            // assertTrue(Invariants.checkInvariant1(address(_wrappedMToken), _accounts), "Invariant 1 Failed.");
+            // assertTrue(Invariants.checkInvariant2(address(_wrappedMToken), _accounts), "Invariant 2 Failed.");
+            assertTrue(Invariants.checkInvariant3(address(_wrappedMToken), address(_mToken)), "Invariant 3 Failed.");
+            // assertTrue(Invariants.checkInvariant4(address(_wrappedMToken), _accounts), "Invariant 4 Failed.");
 
             // console2.log("Wrapper has %s M", _mToken.balanceOf(address(_wrappedMToken)));
 

--- a/test/integration/Protocol.t.sol
+++ b/test/integration/Protocol.t.sol
@@ -99,7 +99,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield -= 1);
-        assertEq(_wrappedMToken.excess(), _excess -= 1);
+        assertEq(_wrappedMToken.excess(), _excess);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -175,7 +175,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += 200_000000);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield -= 1);
-        assertEq(_wrappedMToken.excess(), _excess -= 1);
+        assertEq(_wrappedMToken.excess(), _excess);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -200,7 +200,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 150_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -287,7 +287,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += _aliceBalance);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield -= 1);
-        assertEq(_wrappedMToken.excess(), _excess -= 1);
+        assertEq(_wrappedMToken.excess(), _excess);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -425,7 +425,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield -= 1);
-        assertEq(_wrappedMToken.excess(), _excess -= 1);
+        assertEq(_wrappedMToken.excess(), _excess);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -557,7 +557,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply -= _bobBalance);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         // Assert Bob (Earner)
         assertEq(_mToken.balanceOf(_bob), _bobBalance);
@@ -594,7 +594,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply -= _daveBalance);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         // Assert Dave (Non-Earner)
         assertEq(_mToken.balanceOf(_dave), _daveBalance);

--- a/test/integration/Upgrade.t.sol
+++ b/test/integration/Upgrade.t.sol
@@ -130,7 +130,6 @@ contract UpgradeTests is Test, DeployBase {
 
         // Relevant storage slots.
         assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).totalEarningSupply(), totalEarningSupply_);
-        assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).roundingError(), 0);
 
         for (uint256 index_; index_ < _earners.length; ++index_) {
             assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).balanceWithYieldOf(_earners[index_]), balancesWithYield_[index_]);

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -906,8 +906,7 @@ contract WrappedMTokenTests is Test {
         uint128 currentMIndex_,
         uint240 totalNonEarningSupply_,
         uint240 totalProjectedEarningSupply_,
-        uint112 mPrincipalBalance_,
-        uint144 roundingError_
+        uint112 mPrincipalBalance_
     ) external {
         currentMIndex_ = uint128(bound(currentMIndex_, _EXP_SCALED_ONE, 10 * _EXP_SCALED_ONE));
 
@@ -937,12 +936,7 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setTotalEarningPrincipal(totalEarningPrincipal_);
         _wrappedMToken.setTotalNonEarningSupply(totalNonEarningSupply_);
 
-        roundingError_ = uint144(bound(roundingError_, 0, 1_000_000000));
-
-        _wrappedMToken.setRoundingError(roundingError_);
-
-        uint240 totalProjectedSupply_ = totalNonEarningSupply_ + totalProjectedEarningSupply_;
-        uint240 earmarked_ = totalProjectedSupply_ + roundingError_;
+        uint240 earmarked_ = totalNonEarningSupply_ + totalProjectedEarningSupply_;
         int248 excess_ = earmarked_ <= 0
             ? int248(uint248(mBalance_))
             : int248(uint248(mBalance_)) - int248(uint248(earmarked_));
@@ -1871,27 +1865,19 @@ contract WrappedMTokenTests is Test {
 
         assertEq(_wrappedMToken.excess(), 0);
 
-        _wrappedMToken.setRoundingError(1);
-
-        assertEq(_wrappedMToken.excess(), -1);
-
         _mToken.setBalanceOf(address(_wrappedMToken), 2_101);
-
-        assertEq(_wrappedMToken.excess(), 0);
-
-        _mToken.setBalanceOf(address(_wrappedMToken), 2_102);
 
         assertEq(_wrappedMToken.excess(), 1);
 
+        _mToken.setBalanceOf(address(_wrappedMToken), 2_102);
+
+        assertEq(_wrappedMToken.excess(), 2);
+
         _mToken.setBalanceOf(address(_wrappedMToken), 3_102);
 
-        assertEq(_wrappedMToken.excess(), 1_001);
+        assertEq(_wrappedMToken.excess(), 1_002);
 
         _mToken.setCurrentIndex(1_210000000000);
-
-        assertEq(_wrappedMToken.excess(), 891);
-
-        _wrappedMToken.setRoundingError(0);
 
         assertEq(_wrappedMToken.excess(), 892);
     }
@@ -1901,8 +1887,7 @@ contract WrappedMTokenTests is Test {
         uint128 currentMIndex_,
         uint240 totalNonEarningSupply_,
         uint240 totalProjectedEarningSupply_,
-        uint112 mPrincipalBalance_,
-        uint144 roundingError_
+        uint112 mPrincipalBalance_
     ) external {
         currentMIndex_ = uint128(bound(currentMIndex_, _EXP_SCALED_ONE, 10 * _EXP_SCALED_ONE));
 
@@ -1932,12 +1917,7 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setTotalEarningPrincipal(totalEarningPrincipal_);
         _wrappedMToken.setTotalNonEarningSupply(totalNonEarningSupply_);
 
-        roundingError_ = uint144(bound(roundingError_, 0, 1_000_000000));
-
-        _wrappedMToken.setRoundingError(roundingError_);
-
-        uint240 totalProjectedSupply_ = totalNonEarningSupply_ + totalProjectedEarningSupply_;
-        uint240 earmarked_ = totalProjectedSupply_ + roundingError_;
+        uint240 earmarked_ = totalNonEarningSupply_ + totalProjectedEarningSupply_;
 
         assertLe(_wrappedMToken.excess(), int248(uint248(mBalance_)) - int248(uint248(earmarked_)));
     }

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -907,7 +907,7 @@ contract WrappedMTokenTests is Test {
         uint240 totalNonEarningSupply_,
         uint240 totalProjectedEarningSupply_,
         uint112 mPrincipalBalance_,
-        int144 roundingError_
+        uint144 roundingError_
     ) external {
         currentMIndex_ = uint128(bound(currentMIndex_, _EXP_SCALED_ONE, 10 * _EXP_SCALED_ONE));
 
@@ -937,13 +937,15 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setTotalEarningPrincipal(totalEarningPrincipal_);
         _wrappedMToken.setTotalNonEarningSupply(totalNonEarningSupply_);
 
-        roundingError_ = int144(bound(roundingError_, -1_000_000000, 1_000_000000));
+        roundingError_ = uint144(bound(roundingError_, 0, 1_000_000000));
 
         _wrappedMToken.setRoundingError(roundingError_);
 
         uint240 totalProjectedSupply_ = totalNonEarningSupply_ + totalProjectedEarningSupply_;
-        int248 earmarked_ = int248(uint248(totalProjectedSupply_)) + roundingError_;
-        int248 excess_ = earmarked_ <= 0 ? int248(uint248(mBalance_)) : int248(uint248(mBalance_)) - earmarked_;
+        uint240 earmarked_ = totalProjectedSupply_ + roundingError_;
+        int248 excess_ = earmarked_ <= 0
+            ? int248(uint248(mBalance_))
+            : int248(uint248(mBalance_)) - int248(uint248(earmarked_));
 
         if (excess_ <= 0) {
             vm.expectRevert(IWrappedMToken.NoExcess.selector);
@@ -1892,18 +1894,6 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setRoundingError(0);
 
         assertEq(_wrappedMToken.excess(), 892);
-
-        _wrappedMToken.setRoundingError(-1);
-
-        assertEq(_wrappedMToken.excess(), 893);
-
-        _wrappedMToken.setRoundingError(-2_210);
-
-        assertEq(_wrappedMToken.excess(), 3_102);
-
-        _wrappedMToken.setRoundingError(-2_211);
-
-        assertEq(_wrappedMToken.excess(), 3_102);
     }
 
     function testFuzz_excess(
@@ -1912,7 +1902,7 @@ contract WrappedMTokenTests is Test {
         uint240 totalNonEarningSupply_,
         uint240 totalProjectedEarningSupply_,
         uint112 mPrincipalBalance_,
-        int144 roundingError_
+        uint144 roundingError_
     ) external {
         currentMIndex_ = uint128(bound(currentMIndex_, _EXP_SCALED_ONE, 10 * _EXP_SCALED_ONE));
 
@@ -1942,14 +1932,14 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setTotalEarningPrincipal(totalEarningPrincipal_);
         _wrappedMToken.setTotalNonEarningSupply(totalNonEarningSupply_);
 
-        roundingError_ = int144(bound(roundingError_, -1_000_000000, 1_000_000000));
+        roundingError_ = uint144(bound(roundingError_, 0, 1_000_000000));
 
         _wrappedMToken.setRoundingError(roundingError_);
 
         uint240 totalProjectedSupply_ = totalNonEarningSupply_ + totalProjectedEarningSupply_;
-        int248 earmarked_ = int248(uint248(totalProjectedSupply_)) + roundingError_;
+        uint240 earmarked_ = totalProjectedSupply_ + roundingError_;
 
-        assertLe(_wrappedMToken.excess(), int248(uint248(mBalance_)) - earmarked_);
+        assertLe(_wrappedMToken.excess(), int248(uint248(mBalance_)) - int248(uint248(earmarked_)));
     }
 
     /* ============ totalAccruedYield ============ */

--- a/test/utils/WrappedMTokenHarness.sol
+++ b/test/utils/WrappedMTokenHarness.sol
@@ -73,10 +73,6 @@ contract WrappedMTokenHarness is WrappedMToken {
         _enableDisableEarningIndices.push(index_);
     }
 
-    function setRoundingError(uint256 roundingError_) external {
-        roundingError = uint144(roundingError_);
-    }
-
     function setHasEarnerDetails(address account_, bool hasEarnerDetails_) external {
         _accounts[account_].hasEarnerDetails = hasEarnerDetails_;
     }

--- a/test/utils/WrappedMTokenHarness.sol
+++ b/test/utils/WrappedMTokenHarness.sol
@@ -73,8 +73,8 @@ contract WrappedMTokenHarness is WrappedMToken {
         _enableDisableEarningIndices.push(index_);
     }
 
-    function setRoundingError(int256 roundingError_) external {
-        roundingError = int144(roundingError_);
+    function setRoundingError(uint256 roundingError_) external {
+        roundingError = uint144(roundingError_);
     }
 
     function setHasEarnerDetails(address account_, bool hasEarnerDetails_) external {


### PR DESCRIPTION
Wrapping:
- from non-earner results in exact M loss for earner and exact wM gain for recipient (contract sometimes gains less M than expected)
- from earner results in greater or equal M loss for earner but comparable greater or equal wM gain for the recipient

Unwrapping always result in account losing exact wM and contract sometimes losing more M than expected, but:
- non-earner recipient gains exact M
- earner recipient gains comparable greater or equal M

Claiming excess results in contract sometimes losing a bit more M than expected).