### PR TITLE
Chainsecurity review fixes

### DIFF
--- a/src/EarnerManager.sol
+++ b/src/EarnerManager.sol
@@ -150,7 +150,7 @@ contract EarnerManager is IEarnerManager, Migratable {
     function getEarnerDetails(address account_) external view returns (bool status_, uint16 feeRate_, address admin_) {
         if (earnersListsIgnored() || isInRegistrarEarnersList(account_)) return (true, 0, address(0));
 
-        EarnerDetails storage details_ = _earnerDetails[account_];
+        EarnerDetails memory details_ = _earnerDetails[account_];
 
         // NOTE: Not using `isInAdministratedEarnersList(account_)` here to avoid redundant storage reads.
         return _isValidAdmin(details_.admin) ? (true, details_.feeRate, details_.admin) : (false, 0, address(0));
@@ -179,7 +179,7 @@ contract EarnerManager is IEarnerManager, Migratable {
                 continue;
             }
 
-            EarnerDetails storage details_ = _earnerDetails[account_];
+            EarnerDetails memory details_ = _earnerDetails[account_];
 
             // NOTE: Not using `isInAdministratedEarnersList(account_)` here to avoid redundant storage reads.
             if (!_isValidAdmin(details_.admin)) continue;
@@ -192,7 +192,6 @@ contract EarnerManager is IEarnerManager, Migratable {
 
     /// @inheritdoc IEarnerManager
     function isAdmin(address account_) public view returns (bool isAdmin_) {
-        // TODO: Consider transient storage for memoizing this check.
         return IRegistrarLike(registrar).listContains(ADMINS_LIST_NAME, account_);
     }
 

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -101,9 +101,6 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     /// @inheritdoc IWrappedMToken
     uint128 public disableIndex;
 
-    /// @inheritdoc IWrappedMToken
-    int256 public roundingError;
-
     mapping(address account => address claimRecipient) internal _claimRecipients;
 
     /* ============ Constructor ============ */
@@ -318,10 +315,8 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
         unchecked {
             uint256 earmarked_ = totalNonEarningSupply + projectedEarningSupply();
             uint256 balance_ = _mBalanceOf(address(this));
-            int256 roundingError_ = roundingError > 0 ? roundingError : int256(0);
 
-            // Reduces claimable excess if roundingError is positive, adding an extra layer of safety and solvency.
-            return int256(balance_) - int256(earmarked_) - roundingError_;
+            return int256(balance_) - int256(earmarked_);
         }
     }
 
@@ -669,24 +664,14 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
      * @param  amount_    The amount of M deposited.
      */
     function _wrap(address account_, address recipient_, uint240 amount_) internal {
-        uint240 startingBalance_ = _mBalanceOf(address(this));
-
         // NOTE: The behavior of `IMTokenLike.transferFrom` is known, so its return can be ignored.
         IMTokenLike(mToken).transferFrom(account_, address(this), amount_);
 
-        // NOTE: Computes the actual increase in the $M balance of the `WrappedM` contract and tracks potential $M rounding adjustments.
-        //       Option 1: $M transfer from an $M earner to another $M earner (`WrappedM` in earning state) → rounds up → rounds up,
+        // NOTE: Mints precise amount of Wrapped $M to `recipient_`.
+        //       Option 1: $M transfer from an $M earner to another $M earner (`WrappedM` in earning state): rounds up → rounds up,
         //                 0, 1, or XX extra wei may be locked in `WrappedM` compared to the minted amount of Wrapped $M.
-        //                 Result: `roundingError` remains the same or decreases.
-        //
-        //       Option 2: $M transfer from an $M non-earner to an $M earner (`WrappedM` in earning state) → precise $M transfer → rounds down,
-        //                 0, -1, or -XX wei may be deducted from $M locked in `WrappedM` compared to the minted amount of Wrapped $M.
-        //                 Result: `roundingError` remains the same or increases.
-        uint240 endingBalance_ = _mBalanceOf(address(this));
-        uint240 mIncrease_ = endingBalance_ - startingBalance_;
-        roundingError += int240(amount_) - int240(mIncrease_);
-
-        // Mints precise amount of Wrapped $M to `recipient_`.
+        //       Option 2: $M transfer from an $M non-earner to an $M earner (`WrappedM` in earning state): precise $M transfer → rounds down,
+        //                 0, -1, or -XX wei may be locked in `WrappedM` compared to the minted amount of Wrapped $M.
         _mint(recipient_, amount_);
     }
 
@@ -699,19 +684,12 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     function _unwrap(address account_, address recipient_, uint240 amount_) internal {
         _burn(account_, amount_);
 
-        uint240 startingBalance_ = _mBalanceOf(address(this));
-
         // NOTE: The behavior of `IMTokenLike.transfer` is known, so its return can be ignored.
-        IMTokenLike(mToken).transfer(recipient_, amount_);
-
         // NOTE: Computes the actual decrease in the $M balance of the `WrappedM` contract.
-        //       Option 1: $M transfer from an $M earner (`WrappedM` in earning state) to another $M earner → rounds up.
-        //       Option 2: $M transfer from an $M earner (`WrappedM` in earning state) to an $M non-earner → precise $M transfer.
+        //       Option 1: $M transfer from an $M earner (`WrappedM` in earning state) to another $M earner: round up → rounds up.
+        //       Option 2: $M transfer from an $M earner (`WrappedM` in earning state) to an $M non-earner: round up → precise $M transfer.
         //       In both cases, 0, 1, or XX extra wei may be deducted from the `WrappedM` contract's $M balance compared to the burned amount of Wrapped $M.
-        //       Result: `roundingError` remains the same or increases.
-        uint240 endingBalance_ = _mBalanceOf(address(this));
-        uint240 mDecrease_ = startingBalance_ - endingBalance_;
-        roundingError += int240(mDecrease_) - int240(amount_);
+        IMTokenLike(mToken).transfer(recipient_, amount_);
     }
 
     /**

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -267,6 +267,9 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
 
     /// @inheritdoc IWrappedMToken
     function balanceWithYieldOf(address account_) external view returns (uint256 balance_) {
+        // NOTE: The returned amount includes the total accrued yield, regardless of whether it is split between the claim recipient and the earner manager.
+        //       Claiming yield does not necessarily result in the account's new balance equaling the value returned by `balanceWithYieldOf`,
+        //       as the yield may be directed to a claim recipient different from the `account_` and may be split between the earner manager and the `account_`.
         unchecked {
             return balanceOf(account_) + accruedYieldOf(account_);
         }

--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -302,7 +302,4 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
 
     /// @notice The address of the destination where excess is claimed to.
     function excessDestination() external view returns (address excessDestination);
-
-    /// @notice The rounding error that may occur due to imprecise $M transfers in and out of WrappedM contract.
-    function roundingError() external view returns (int256 roundingError);
 }

--- a/test/integration/Protocol.t.sol
+++ b/test/integration/Protocol.t.sol
@@ -99,8 +99,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
-        assertEq(_wrappedMToken.roundingError(), 1);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -125,7 +124,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 50_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
         assertEq(_wrappedMToken.excess(), _excess);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -177,8 +175,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += 200_000000);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
-        assertEq(_wrappedMToken.roundingError(), 2);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -203,8 +200,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 150_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
-        assertEq(_wrappedMToken.roundingError(), 3);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -226,7 +222,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield -= 1_190592);
         assertEq(_wrappedMToken.excess(), _excess);
-        assertEq(_wrappedMToken.roundingError(), 3);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -292,8 +287,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += _aliceBalance);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
-        assertEq(_wrappedMToken.roundingError(), 1);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -344,7 +338,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += _daveBalance + _aliceBalance);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield += 1);
         assertEq(_wrappedMToken.excess(), _excess -= 1);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         // Assert Carol (Non-Earner)
         assertEq(_wrappedMToken.balanceOf(_carol), _carolBalance += _aliceBalance);
@@ -374,7 +367,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply -= 50_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield += 1);
         assertEq(_wrappedMToken.excess(), _excess -= 1);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -433,8 +425,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
-        assertEq(_wrappedMToken.roundingError(), 1);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -467,7 +458,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += 100_000000);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield += 1);
         assertEq(_wrappedMToken.excess(), _excess -= 1);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -500,7 +490,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply += _aliceBalance);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield -= 3_614473 + 1);
         assertEq(_wrappedMToken.excess(), _excess += 1);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -521,7 +510,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply -= _carolBalance);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield += 1);
         assertEq(_wrappedMToken.excess(), _excess -= 1);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -551,7 +539,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply -= _aliceBalance);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
         assertEq(_wrappedMToken.excess(), _excess);
-        assertEq(_wrappedMToken.roundingError(), 1);
 
         // Assert Alice (Non-Earner)
         assertEq(_mToken.balanceOf(_alice), _aliceBalance);
@@ -570,8 +557,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply -= _bobBalance);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield += 1);
-        assertEq(_wrappedMToken.excess(), _excess -= 3);
-        assertEq(_wrappedMToken.roundingError(), 2);
+        assertEq(_wrappedMToken.excess(), _excess -= 2);
 
         // Assert Bob (Earner)
         assertEq(_mToken.balanceOf(_bob), _bobBalance);
@@ -591,7 +577,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield += 1);
         assertEq(_wrappedMToken.excess(), _excess -= 1);
-        assertEq(_wrappedMToken.roundingError(), 2);
 
         // Assert Carol (Earner)
         assertEq(_mToken.balanceOf(_carol), _carolBalance);
@@ -609,8 +594,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalEarningSupply(), _totalEarningSupply);
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply -= _daveBalance);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
-        assertEq(_wrappedMToken.excess(), _excess -= 2);
-        assertEq(_wrappedMToken.roundingError(), 3);
+        assertEq(_wrappedMToken.excess(), _excess -= 1);
 
         // Assert Dave (Non-Earner)
         assertEq(_mToken.balanceOf(_dave), _daveBalance);
@@ -633,7 +617,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.totalNonEarningSupply(), _totalNonEarningSupply);
         assertEq(_wrappedMToken.totalAccruedYield(), _totalAccruedYield);
         assertEq(_wrappedMToken.excess(), _excess -= _excess);
-        assertEq(_wrappedMToken.roundingError(), 3);
 
         assertGe(
             int256(_wrapperBalanceOfM),
@@ -774,92 +757,6 @@ contract ProtocolIntegrationTests is TestBase {
                 continue;
             }
         }
-    }
-
-    function test_integration_roundingError() external {
-        // Alice is $M earner, bob is not
-        vm.prank(_alice);
-        _mToken.startEarning();
-
-        _giveM(_alice, 100_000000);
-        _giveM(_bob, 100_000000);
-
-        // Wraps for earners and non-earners with different values of $M index (timestamps)
-        uint256 mBalanceBeforeWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _wrap(_alice, _alice, 10_000000);
-        uint256 mBalanceAfterWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-
-        uint256 mDelta = mBalanceAfterWrap_ - mBalanceBeforeWrap_;
-
-        assertEq(mDelta, 10000001);
-        assertEq(_wrappedMToken.roundingError(), -1);
-
-        mBalanceBeforeWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _wrap(_bob, _bob, 10_000000);
-        mBalanceAfterWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-
-        mDelta = mBalanceAfterWrap_ - mBalanceBeforeWrap_;
-
-        assertEq(mDelta, 10000000);
-        assertEq(_wrappedMToken.roundingError(), -1);
-
-        vm.warp(vm.getBlockTimestamp() + 5 seconds);
-
-        mBalanceBeforeWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _wrap(_bob, _bob, 10_000000);
-        mBalanceAfterWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-
-        mDelta = mBalanceAfterWrap_ - mBalanceBeforeWrap_;
-
-        assertEq(mDelta, 9999999);
-        assertEq(_wrappedMToken.roundingError(), 0);
-
-        mBalanceBeforeWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _wrap(_alice, _alice, 10_000000);
-        mBalanceAfterWrap_ = _mToken.balanceOf(address(_wrappedMToken));
-
-        mDelta = mBalanceAfterWrap_ - mBalanceBeforeWrap_;
-
-        assertEq(mDelta, 10000000);
-        assertEq(_wrappedMToken.roundingError(), 0);
-
-        // Unwraps
-
-        uint256 mBalanceBeforeUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _unwrap(_alice, _alice, 10_000000);
-        uint256 mBalanceAfterUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        mDelta = mBalanceBeforeUnwrap_ - mBalanceAfterUnwrap_;
-
-        assertEq(mDelta, 10000000);
-        assertEq(_wrappedMToken.roundingError(), 0);
-
-        mBalanceBeforeUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _unwrap(_bob, _bob, 10_000000);
-        mBalanceAfterUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        mDelta = mBalanceBeforeUnwrap_ - mBalanceAfterUnwrap_;
-
-        assertEq(mDelta, 10_000000);
-        assertEq(_wrappedMToken.roundingError(), 0);
-
-        vm.warp(vm.getBlockTimestamp() + 10 minutes);
-
-        mBalanceBeforeUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _unwrap(_alice, _alice, 10_000000);
-        mBalanceAfterUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        mDelta = mBalanceBeforeUnwrap_ - mBalanceAfterUnwrap_;
-
-        assertEq(mDelta, 10_000001);
-        assertEq(_wrappedMToken.roundingError(), 1);
-
-        vm.warp(vm.getBlockTimestamp() + 90 minutes);
-
-        mBalanceBeforeUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        _unwrap(_bob, _bob, 10_000000);
-        mBalanceAfterUnwrap_ = _mToken.balanceOf(address(_wrappedMToken));
-        mDelta = mBalanceBeforeUnwrap_ - mBalanceAfterUnwrap_;
-
-        assertEq(mDelta, 10_000001);
-        assertEq(_wrappedMToken.roundingError(), 2);
     }
 
     function _getNewSeed(uint256 seed_) internal pure returns (uint256 newSeed_) {


### PR DESCRIPTION
- remove optional rounding error 
- change `storage` into `memory` for EarnerDetails loading
- a few extra comments and removal of TODO statement