### PR TITLE
feat: use SwapFacility

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -6,6 +6,7 @@ EXPECTED_PROXY= # Address of the expected Wrapped M proxy
 M_TOKEN= # Address of the M token
 REGISTRAR= # Address of the Registrar
 EXCESS_DESTINATION= # Address of the Excess Destination
+SWAP_FACILITY= # Address of the Swap Facility
 MIGRATION_ADMIN= # Address of the Migration Admin
 
 # RPC URL to deploy to

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -70,6 +70,7 @@ contract DeployProduction is Script, DeployBase {
             vm.envAddress("M_TOKEN"),
             vm.envAddress("REGISTRAR"),
             vm.envAddress("EXCESS_DESTINATION"),
+            vm.envAddress("SWAP_FACILITY"),
             vm.envAddress("WRAPPED_M_MIGRATION_ADMIN"),
             vm.envAddress("EARNER_MANAGER_MIGRATION_ADMIN")
         );

--- a/script/DeployBase.sol
+++ b/script/DeployBase.sol
@@ -14,6 +14,7 @@ contract DeployBase {
      * @dev    Deploys Wrapped M Token.
      * @param  mToken_                      The address of the M Token contract.
      * @param  registrar_                   The address of the Registrar contract.
+     * @param  swapFacility_                The address of the SwapFacility contract.
      * @param  excessDestination_           The address of the excess destination.
      * @param  wrappedMMigrationAdmin_      The address of the Wrapped M Migration Admin.
      * @param  earnerManagerMigrationAdmin_ The address of the Earner Manager Migration Admin.
@@ -26,6 +27,7 @@ contract DeployBase {
         address mToken_,
         address registrar_,
         address excessDestination_,
+        address swapFacility_,
         address wrappedMMigrationAdmin_,
         address earnerManagerMigrationAdmin_
     )
@@ -48,7 +50,7 @@ contract DeployBase {
         earnerManagerProxy_ = address(new Proxy(earnerManagerImplementation_));
 
         wrappedMTokenImplementation_ = address(
-            new WrappedMToken(mToken_, registrar_, earnerManagerProxy_, excessDestination_, wrappedMMigrationAdmin_)
+            new WrappedMToken(mToken_, registrar_, earnerManagerProxy_, excessDestination_, swapFacility_, wrappedMMigrationAdmin_)
         );
 
         wrappedMTokenProxy_ = address(new Proxy(wrappedMTokenImplementation_));
@@ -59,6 +61,7 @@ contract DeployBase {
      * @param  mToken_                      The address of the M Token contract.
      * @param  registrar_                   The address of the Registrar contract.
      * @param  excessDestination_           The address of the excess destination.
+     * @param  swapFacility_                The address of the SwapFacility contract.
      * @param  wrappedMMigrationAdmin_      The address of the Wrapped M Migration Admin.
      * @param  earnerManagerMigrationAdmin_ The address of the Earner Manager Migration Admin.
      * @return earnerManagerImplementation_ The address of the deployed Earner Manager implementation.
@@ -70,6 +73,7 @@ contract DeployBase {
         address mToken_,
         address registrar_,
         address excessDestination_,
+        address swapFacility_,
         address wrappedMMigrationAdmin_,
         address earnerManagerMigrationAdmin_,
         address[] memory earners_
@@ -93,7 +97,7 @@ contract DeployBase {
         earnerManagerProxy_ = address(new Proxy(earnerManagerImplementation_));
 
         wrappedMTokenImplementation_ = address(
-            new WrappedMToken(mToken_, registrar_, earnerManagerProxy_, excessDestination_, wrappedMMigrationAdmin_)
+            new WrappedMToken(mToken_, registrar_, earnerManagerProxy_, excessDestination_, swapFacility_, wrappedMMigrationAdmin_)
         );
 
         wrappedMTokenMigrator_ = address(new WrappedMTokenMigratorV1(wrappedMTokenImplementation_, earners_));

--- a/script/DeployUpgradeMainnet.s.sol
+++ b/script/DeployUpgradeMainnet.s.sol
@@ -22,6 +22,9 @@ contract DeployUpgradeMainnet is Script, DeployBase {
     // NOTE: Ensure this is the correct Excess Destination mainnet address.
     address internal constant _EXCESS_DESTINATION = 0xd7298f620B0F752Cf41BD818a16C756d9dCAA34f; // Vault
 
+    // TODO: Replace with the correct Swap Facility mainnet address after deployment.
+    address internal constant _SWAP_FACILITY = address(0);
+
     address internal constant _M_TOKEN = 0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b;
 
     // NOTE: Ensure this is the correct Migration Admin mainnet address.
@@ -137,6 +140,7 @@ contract DeployUpgradeMainnet is Script, DeployBase {
             _M_TOKEN,
             _REGISTRAR,
             _EXCESS_DESTINATION,
+            _SWAP_FACILITY,
             _WRAPPED_M_MIGRATION_ADMIN,
             _EARNER_MANAGER_MIGRATION_ADMIN,
             earners_

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -84,6 +84,9 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     address public immutable excessDestination;
 
     /// @inheritdoc IWrappedMToken
+    address public immutable swapFacility;
+
+    /// @inheritdoc IWrappedMToken
     uint112 public totalEarningPrincipal;
 
     /// @inheritdoc IWrappedMToken
@@ -103,6 +106,14 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
 
     mapping(address account => address claimRecipient) internal _claimRecipients;
 
+    /* ============ Modifiers ============ */
+
+    /// @dev Modifier to check if caller is SwapFacility.
+    modifier onlySwapFacility() {
+        if (msg.sender != swapFacility) revert NotSwapFacility();
+        _;
+    }
+
     /* ============ Constructor ============ */
 
     /**
@@ -112,6 +123,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
      * @param registrar_         The address of a Registrar.
      * @param earnerManager_     The address of an Earner Manager.
      * @param excessDestination_ The address of an excess destination.
+     * @param swapFacility_      The address of a Swap Facility.
      * @param migrationAdmin_    The address of a migration admin.
      */
     constructor(
@@ -119,46 +131,27 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
         address registrar_,
         address earnerManager_,
         address excessDestination_,
+        address swapFacility_,
         address migrationAdmin_
     ) ERC20Extended("M (Wrapped) by M^0", "wM", 6) {
         if ((mToken = mToken_) == address(0)) revert ZeroMToken();
         if ((registrar = registrar_) == address(0)) revert ZeroRegistrar();
         if ((earnerManager = earnerManager_) == address(0)) revert ZeroEarnerManager();
         if ((excessDestination = excessDestination_) == address(0)) revert ZeroExcessDestination();
+        if ((swapFacility = swapFacility_) == address(0)) revert ZeroSwapFacility();
         if ((migrationAdmin = migrationAdmin_) == address(0)) revert ZeroMigrationAdmin();
     }
 
     /* ============ Interactive Functions ============ */
 
     /// @inheritdoc IWrappedMToken
-    function wrap(address recipient_, uint256 amount_) external {
-        _wrap(msg.sender, recipient_, UIntMath.safe240(amount_));
+    function wrap(address recipient_, uint256 amount_) external onlySwapFacility {
+        _wrap(recipient_, UIntMath.safe240(amount_));
     }
 
     /// @inheritdoc IWrappedMToken
-    function wrapWithPermit(
-        address recipient_,
-        uint256 amount_,
-        uint256 deadline_,
-        uint8 v_,
-        bytes32 r_,
-        bytes32 s_
-    ) external {
-        try IMTokenLike(mToken).permit(msg.sender, address(this), amount_, deadline_, v_, r_, s_) {} catch {}
-
-        _wrap(msg.sender, recipient_, UIntMath.safe240(amount_));
-    }
-
-    /// @inheritdoc IWrappedMToken
-    function wrapWithPermit(address recipient_, uint256 amount_, uint256 deadline_, bytes memory signature_) external {
-        try IMTokenLike(mToken).permit(msg.sender, address(this), amount_, deadline_, signature_) {} catch {}
-
-        _wrap(msg.sender, recipient_, UIntMath.safe240(amount_));
-    }
-
-    /// @inheritdoc IWrappedMToken
-    function unwrap(address recipient_, uint256 amount_) external {
-        _unwrap(msg.sender, recipient_, UIntMath.safe240(amount_));
+    function unwrap(address /* recipient_ */, uint256 amount_) external onlySwapFacility {
+        _unwrap(UIntMath.safe240(amount_));
     }
 
     /// @inheritdoc IWrappedMToken
@@ -662,13 +655,13 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
 
     /**
      * @dev    Wraps `amount` M from `account_` into wM for `recipient`.
-     * @param  account_   The account from which M is deposited.
      * @param  recipient_ The account receiving the minted wM.
      * @param  amount_    The amount of M deposited.
      */
-    function _wrap(address account_, address recipient_, uint240 amount_) internal {
+    function _wrap(address recipient_, uint240 amount_) internal {
+        // NOTE: Always transfer from SwapFacility as it is the only contract that can call this function.
         // NOTE: The behavior of `IMTokenLike.transferFrom` is known, so its return can be ignored.
-        IMTokenLike(mToken).transferFrom(account_, address(this), amount_);
+        IMTokenLike(mToken).transferFrom(msg.sender, address(this), amount_);
 
         // NOTE: Mints precise amount of Wrapped $M to `recipient_`.
         //       Option 1: $M transfer from an $M earner to another $M earner (`WrappedM` in earning state): rounds up → rounds up,
@@ -679,20 +672,19 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     }
 
     /**
-     * @dev    Unwraps `amount` wM from `account_` into M for `recipient`.
-     * @param  account_   The account from which WM is burned.
-     * @param  recipient_ The account receiving the withdrawn M.
+     * @dev    Unwraps `amount` wM from `account_` into M.
      * @param  amount_    The amount of wM burned.
      */
-    function _unwrap(address account_, address recipient_, uint240 amount_) internal {
-        _burn(account_, amount_);
+    function _unwrap(uint240 amount_) internal {
+        // NOTE: Always burn from SwapFacility as it is the only contract that can call this function.
+        _burn(msg.sender, amount_);
 
         // NOTE: The behavior of `IMTokenLike.transfer` is known, so its return can be ignored.
         // NOTE: Computes the actual decrease in the $M balance of the `WrappedM` contract.
         //       Option 1: $M transfer from an $M earner (`WrappedM` in earning state) to another $M earner: round up → rounds up.
         //       Option 2: $M transfer from an $M earner (`WrappedM` in earning state) to an $M non-earner: round up → precise $M transfer.
         //       In both cases, 0, 1, or XX extra wei may be deducted from the `WrappedM` contract's $M balance compared to the burned amount of Wrapped $M.
-        IMTokenLike(mToken).transfer(recipient_, amount_);
+        IMTokenLike(mToken).transfer(msg.sender, amount_);
     }
 
     /**

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -28,7 +28,7 @@ import { IWrappedMToken } from "./interfaces/IWrappedMToken.sol";
 
 /**
  * @title  ERC20 Token contract for wrapping M into a non-rebasing token with claimable yields.
- * @author M^0 Labs
+ * @author M0 Labs
  */
 contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
     /* ============ Structs ============ */
@@ -133,7 +133,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended {
         address excessDestination_,
         address swapFacility_,
         address migrationAdmin_
-    ) ERC20Extended("M (Wrapped) by M^0", "wM", 6) {
+    ) ERC20Extended("M (Wrapped) by M0", "wM", 6) {
         if ((mToken = mToken_) == address(0)) revert ZeroMToken();
         if ((registrar = registrar_) == address(0)) revert ZeroRegistrar();
         if ((earnerManager = earnerManager_) == address(0)) revert ZeroEarnerManager();

--- a/src/interfaces/ISwapFacilityLike.sol
+++ b/src/interfaces/ISwapFacilityLike.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+pragma solidity 0.8.26;
+
+/**
+ * @title  Subset of SwapFacility interface.
+ * @author M0 Labs
+ */
+interface ISwapFacilityLike {
+    /**
+     * @notice Swaps $M token to $M Extension.
+     * @param  extensionOut The address of the M Extension to swap to.
+     * @param  amount       The amount of $M token to swap.
+     * @param  recipient    The address to receive the swapped $M Extension tokens.
+     */
+    function swapInM(address extensionOut, uint256 amount, address recipient) external;
+
+    /**
+     * @notice Swaps $M Extension to $M token.
+     * @param  extensionIn The address of the $M Extension to swap from.
+     * @param  amount      The amount of $M Extension tokens to swap.
+     * @param  recipient   The address to receive $M tokens.
+     */
+    function swapOutM(address extensionIn, uint256 amount, address recipient) external;
+}

--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -103,44 +103,25 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
     /// @notice Emitted in constructor if Registrar is 0x0.
     error ZeroRegistrar();
 
+    /// @notice Emitted in constructor if SwapFacility is 0x0.
+    error ZeroSwapFacility();
+
+    /// @notice Emitted in `wrap` and `unwrap` functions if the caller is not the SwapFacility.
+    error NotSwapFacility();
+
     /* ============ Interactive Functions ============ */
 
     /**
      * @notice Wraps `amount` M from the caller into wM for `recipient`.
+     * @dev    Can only be called by the SwapFacility.
      * @param  recipient The account receiving the minted wM.
      * @param  amount    The amount of wM minted.
      */
     function wrap(address recipient, uint256 amount) external;
 
     /**
-     * @notice Wraps `amount` M from the caller into wM for `recipient`, using a permit.
-     * @param  recipient The account receiving the minted wM.
-     * @param  amount    The amount of M deposited.
-     * @param  deadline  The last timestamp where the signature is still valid.
-     * @param  v         An ECDSA secp256k1 signature parameter (EIP-2612 via EIP-712).
-     * @param  r         An ECDSA secp256k1 signature parameter (EIP-2612 via EIP-712).
-     * @param  s         An ECDSA secp256k1 signature parameter (EIP-2612 via EIP-712).
-     */
-    function wrapWithPermit(
-        address recipient,
-        uint256 amount,
-        uint256 deadline,
-        uint8 v,
-        bytes32 r,
-        bytes32 s
-    ) external;
-
-    /**
-     * @notice Wraps `amount` M from the caller into wM for `recipient`, using a permit.
-     * @param  recipient The account receiving the minted wM.
-     * @param  amount    The amount of M deposited.
-     * @param  deadline  The last timestamp where the signature is still valid.
-     * @param  signature An arbitrary signature (EIP-712).
-     */
-    function wrapWithPermit(address recipient, uint256 amount, uint256 deadline, bytes memory signature) external;
-
-    /**
      * @notice Unwraps `amount` wM from the caller into M for `recipient`.
+     * @dev    Can only be called by the SwapFacility.
      * @param  recipient The account receiving the withdrawn M.
      * @param  amount    The amount of wM burned.
      */
@@ -299,4 +280,7 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
 
     /// @notice The address of the destination where excess is claimed to.
     function excessDestination() external view returns (address excessDestination);
+
+    /// @notice The address of the Swap Facility contract
+    function swapFacility() external view returns (address swapFacility);
 }

--- a/test/integration/Deploy.t.sol
+++ b/test/integration/Deploy.t.sol
@@ -15,6 +15,8 @@ contract DeployTests is Test, DeployBase {
     address internal constant _WRAPPED_M_MIGRATION_ADMIN = 0x431169728D75bd02f4053435b87D15c8d1FB2C72;
     address internal constant _EARNER_MANAGER_MIGRATION_ADMIN = 0x431169728D75bd02f4053435b87D15c8d1FB2C72;
     address internal constant _EXCESS_DESTINATION = 0xd7298f620B0F752Cf41BD818a16C756d9dCAA34f; // Vault
+    // TODO: Replace with the actual Swap Facility address after deployment.
+    address internal constant _SWAP_FACILITY = 0x0000000000000000000000000000000000000001;
     address internal constant _DEPLOYER = 0xF2f1ACbe0BA726fEE8d75f3E32900526874740BB;
 
     uint64 internal constant _DEPLOYER_NONCE = 50;
@@ -39,6 +41,7 @@ contract DeployTests is Test, DeployBase {
                 _M_TOKEN,
                 _REGISTRAR,
                 _EXCESS_DESTINATION,
+                _SWAP_FACILITY,
                 _WRAPPED_M_MIGRATION_ADMIN,
                 _EARNER_MANAGER_MIGRATION_ADMIN
             );
@@ -60,6 +63,7 @@ contract DeployTests is Test, DeployBase {
         assertEq(IWrappedMToken(wrappedMTokenImplementation_).mToken(), _M_TOKEN);
         assertEq(IWrappedMToken(wrappedMTokenImplementation_).registrar(), _REGISTRAR);
         assertEq(IWrappedMToken(wrappedMTokenImplementation_).excessDestination(), _EXCESS_DESTINATION);
+        assertEq(IWrappedMToken(wrappedMTokenImplementation_).swapFacility(), _SWAP_FACILITY);
 
         // Wrapped M Token Proxy assertions
         assertEq(wrappedMTokenProxy_, expectedWrappedMTokenProxy_);
@@ -68,6 +72,7 @@ contract DeployTests is Test, DeployBase {
         assertEq(IWrappedMToken(wrappedMTokenProxy_).mToken(), _M_TOKEN);
         assertEq(IWrappedMToken(wrappedMTokenProxy_).registrar(), _REGISTRAR);
         assertEq(IWrappedMToken(wrappedMTokenProxy_).excessDestination(), _EXCESS_DESTINATION);
+        assertEq(IWrappedMToken(wrappedMTokenProxy_).swapFacility(), _SWAP_FACILITY);
         assertEq(IWrappedMToken(wrappedMTokenProxy_).implementation(), wrappedMTokenImplementation_);
     }
 }

--- a/test/integration/Protocol.t.sol
+++ b/test/integration/Protocol.t.sol
@@ -54,7 +54,7 @@ contract ProtocolIntegrationTests is TestBase {
         assertEq(_wrappedMToken.EARNERS_LIST_NAME(), "earners");
         assertEq(_wrappedMToken.CLAIM_OVERRIDE_RECIPIENT_KEY_PREFIX(), "wm_claim_override_recipient");
         assertEq(_wrappedMToken.MIGRATOR_KEY_PREFIX(), "wm_migrator_v2");
-        assertEq(_wrappedMToken.name(), "M (Wrapped) by M^0");
+        assertEq(_wrappedMToken.name(), "M (Wrapped) by M0");
         assertEq(_wrappedMToken.symbol(), "wM");
         assertEq(_wrappedMToken.decimals(), 6);
     }

--- a/test/integration/Protocol.t.sol
+++ b/test/integration/Protocol.t.sol
@@ -64,22 +64,6 @@ contract ProtocolIntegrationTests is TestBase {
         assertTrue(_mToken.isEarning(address(_wrappedMToken)));
     }
 
-    function test_wrapWithPermits() external {
-        _giveM(_alice, 200_000000);
-
-        assertEq(_mToken.balanceOf(_alice), 200_000000);
-
-        _wrapWithPermitVRS(_alice, _aliceKey, _alice, 100_000000, 0, block.timestamp);
-
-        assertEq(_mToken.balanceOf(_alice), 100_000000);
-        assertEq(_wrappedMToken.balanceOf(_alice), 100_000000);
-
-        _wrapWithPermitSignature(_alice, _aliceKey, _alice, 100_000000, 1, block.timestamp);
-
-        assertEq(_mToken.balanceOf(_alice), 0);
-        assertEq(_wrappedMToken.balanceOf(_alice), 200_000000);
-    }
-
     function test_integration_yieldAccumulation() external {
         _giveM(_alice, 100_000000);
 

--- a/test/integration/TestBase.sol
+++ b/test/integration/TestBase.sol
@@ -10,12 +10,15 @@ import { Test } from "../../lib/forge-std/src/Test.sol";
 import { Proxy } from "../../lib/common/src/Proxy.sol";
 
 import { IWrappedMToken } from "../../src/interfaces/IWrappedMToken.sol";
+import { ISwapFacilityLike } from "../../src/interfaces/ISwapFacilityLike.sol";
 
 import { EarnerManager } from "../../src/EarnerManager.sol";
 import { WrappedMToken } from "../../src/WrappedMToken.sol";
 import { WrappedMTokenMigratorV1 } from "../../src/WrappedMTokenMigratorV1.sol";
 
 import { IMTokenLike, IRegistrarLike } from "./vendor/protocol/Interfaces.sol";
+
+import { MockSwapFacility } from "../utils/Mocks.sol";
 
 contract TestBase is Test {
     IMTokenLike internal constant _mToken = IMTokenLike(0x866A2BF4E572CbcF37D5071A7a58503Bfb36be1b);
@@ -67,6 +70,9 @@ contract TestBase is Test {
     address internal _earnerManager;
     address internal _wrappedMTokenImplementationV2;
     address internal _wrappedMTokenMigratorV1;
+
+    // TODO: Replace with the actual Swap Facility address after deployment.
+    address internal _swapFacility;
 
     address[] internal _earners = [
         0x437cc33344a0B27A429f795ff6B469C72698B291,
@@ -145,43 +151,18 @@ contract TestBase is Test {
 
     function _wrap(address account_, address recipient_, uint256 amount_) internal {
         vm.prank(account_);
-        _mToken.approve(address(_wrappedMToken), amount_);
+        _mToken.approve(_swapFacility, amount_);
 
         vm.prank(account_);
-        _wrappedMToken.wrap(recipient_, amount_);
-    }
-
-    function _wrapWithPermitVRS(
-        address account_,
-        uint256 signerPrivateKey_,
-        address recipient_,
-        uint256 amount_,
-        uint256 nonce_,
-        uint256 deadline_
-    ) internal {
-        (uint8 v_, bytes32 r_, bytes32 s_) = _getPermit(account_, signerPrivateKey_, amount_, nonce_, deadline_);
-
-        vm.prank(account_);
-        _wrappedMToken.wrapWithPermit(recipient_, amount_, deadline_, v_, r_, s_);
-    }
-
-    function _wrapWithPermitSignature(
-        address account_,
-        uint256 signerPrivateKey_,
-        address recipient_,
-        uint256 amount_,
-        uint256 nonce_,
-        uint256 deadline_
-    ) internal {
-        (uint8 v_, bytes32 r_, bytes32 s_) = _getPermit(account_, signerPrivateKey_, amount_, nonce_, deadline_);
-
-        vm.prank(account_);
-        _wrappedMToken.wrapWithPermit(recipient_, amount_, deadline_, abi.encodePacked(r_, s_, v_));
+        ISwapFacilityLike(_swapFacility).swapInM(address(_wrappedMToken), amount_, recipient_);
     }
 
     function _unwrap(address account_, address recipient_, uint256 amount_) internal {
         vm.prank(account_);
-        _wrappedMToken.unwrap(recipient_, amount_);
+        _wrappedMToken.approve(_swapFacility, amount_);
+
+        vm.prank(account_);
+        ISwapFacilityLike(_swapFacility).swapOutM(address(_wrappedMToken), amount_, recipient_);
     }
 
     function _transferWM(address sender_, address recipient_, uint256 amount_) internal {
@@ -206,8 +187,17 @@ contract TestBase is Test {
     function _deployV2Components() internal {
         _earnerManagerImplementation = address(new EarnerManager(_registrar, _migrationAdmin));
         _earnerManager = address(new Proxy(_earnerManagerImplementation));
+        // TODO: Replace with the actual Swap Facility address after deployment.
+        _swapFacility = address(new MockSwapFacility(address(_mToken)));
         _wrappedMTokenImplementationV2 = address(
-            new WrappedMToken(address(_mToken), _registrar, _earnerManager, _excessDestination, _migrationAdmin)
+            new WrappedMToken(
+                address(_mToken),
+                _registrar,
+                _earnerManager,
+                _excessDestination,
+                _swapFacility,
+                _migrationAdmin
+            )
         );
 
         address[] memory earners_ = new address[](_earners.length);

--- a/test/integration/Upgrade.t.sol
+++ b/test/integration/Upgrade.t.sol
@@ -16,6 +16,8 @@ contract UpgradeTests is Test, DeployBase {
     address internal constant _WRAPPED_M_MIGRATION_ADMIN = 0x431169728D75bd02f4053435b87D15c8d1FB2C72;
     address internal constant _EARNER_MANAGER_MIGRATION_ADMIN = 0x431169728D75bd02f4053435b87D15c8d1FB2C72;
     address internal constant _EXCESS_DESTINATION = 0xd7298f620B0F752Cf41BD818a16C756d9dCAA34f; // Vault
+    // TODO: Replace with the actual Swap Facility address after deployment.
+    address internal constant _SWAP_FACILITY = 0x0000000000000000000000000000000000000001;
     address internal constant _DEPLOYER = 0xF2f1ACbe0BA726fEE8d75f3E32900526874740BB;
 
     uint64 internal constant _DEPLOYER_NONCE = 50;
@@ -84,6 +86,7 @@ contract UpgradeTests is Test, DeployBase {
                 _M_TOKEN,
                 _REGISTRAR,
                 _EXCESS_DESTINATION,
+                _SWAP_FACILITY,
                 _WRAPPED_M_MIGRATION_ADMIN,
                 _EARNER_MANAGER_MIGRATION_ADMIN,
                 earners_
@@ -106,6 +109,7 @@ contract UpgradeTests is Test, DeployBase {
         assertEq(IWrappedMToken(wrappedMTokenImplementation_).mToken(), _M_TOKEN);
         assertEq(IWrappedMToken(wrappedMTokenImplementation_).registrar(), _REGISTRAR);
         assertEq(IWrappedMToken(wrappedMTokenImplementation_).excessDestination(), _EXCESS_DESTINATION);
+        assertEq(IWrappedMToken(wrappedMTokenImplementation_).swapFacility(), _SWAP_FACILITY);
 
         // Migrator assertions
         assertEq(wrappedMTokenMigrator_, expectedWrappedMTokenMigrator_);
@@ -126,6 +130,7 @@ contract UpgradeTests is Test, DeployBase {
         assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).mToken(), _M_TOKEN);
         assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).registrar(), _REGISTRAR);
         assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).excessDestination(), _EXCESS_DESTINATION);
+        assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).swapFacility(), _SWAP_FACILITY);
         assertEq(IWrappedMToken(_WRAPPED_M_TOKEN).implementation(), wrappedMTokenImplementation_);
 
         // Relevant storage slots.

--- a/test/unit/Migrations.t.sol
+++ b/test/unit/Migrations.t.sol
@@ -50,6 +50,7 @@ contract MigrationTests is Test {
     address internal _mToken = makeAddr("mToken");
     address internal _earnerManager = makeAddr("earnerManager");
     address internal _excessDestination = makeAddr("excessDestination");
+    address internal _swapFacility = makeAddr("swapFacility");
     address internal _migrationAdmin = makeAddr("migrationAdmin");
 
     function test_wrappedMToken_migration() external {
@@ -62,6 +63,7 @@ contract MigrationTests is Test {
                 address(registrar_),
                 _earnerManager,
                 _excessDestination,
+                _swapFacility,
                 _migrationAdmin
             )
         );
@@ -89,6 +91,7 @@ contract MigrationTests is Test {
                 address(registrar_),
                 _earnerManager,
                 _excessDestination,
+                _swapFacility,
                 _migrationAdmin
             )
         );

--- a/test/unit/Stories.t.sol
+++ b/test/unit/Stories.t.sol
@@ -11,7 +11,7 @@ import { IWrappedMToken } from "../../src/interfaces/IWrappedMToken.sol";
 
 import { WrappedMToken } from "../../src/WrappedMToken.sol";
 
-import { MockEarnerManager, MockM, MockRegistrar } from "../utils/Mocks.sol";
+import { MockEarnerManager, MockM, MockRegistrar, MockSwapFacility } from "../utils/Mocks.sol";
 
 contract StoryTests is Test {
     uint56 internal constant _EXP_SCALED_ONE = IndexingMath.EXP_SCALED_ONE;
@@ -29,6 +29,7 @@ contract StoryTests is Test {
     MockEarnerManager internal _earnerManager;
     MockM internal _mToken;
     MockRegistrar internal _registrar;
+    MockSwapFacility internal _swapFacility;
     WrappedMToken internal _implementation;
     IWrappedMToken internal _wrappedMToken;
 
@@ -37,6 +38,7 @@ contract StoryTests is Test {
 
         _mToken = new MockM();
         _mToken.setCurrentIndex(_EXP_SCALED_ONE);
+        _swapFacility = new MockSwapFacility(address(_mToken));
 
         _earnerManager = new MockEarnerManager();
 
@@ -45,6 +47,7 @@ contract StoryTests is Test {
             address(_registrar),
             address(_earnerManager),
             _excessDestination,
+            address(_swapFacility),
             _migrationAdmin
         );
 
@@ -65,7 +68,7 @@ contract StoryTests is Test {
         _mToken.setBalanceOf(_alice, 100_000000);
 
         vm.prank(_alice);
-        _wrappedMToken.wrap(_alice, 100_000000);
+        _swapFacility.swapInM(address(_wrappedMToken), 100_000000, _alice);
 
         // Assert Alice (Earner)
         assertEq(_wrappedMToken.balanceOf(_alice), 100_000000);
@@ -81,7 +84,7 @@ contract StoryTests is Test {
         _mToken.setBalanceOf(_carol, 100_000000);
 
         vm.prank(_carol);
-        _wrappedMToken.wrap(_carol, 100_000000);
+        _swapFacility.swapInM(address(_wrappedMToken), 100_000000, _carol);
 
         // Assert Carol (Non-Earner)
         assertEq(_wrappedMToken.balanceOf(_carol), 100_000000);
@@ -115,7 +118,7 @@ contract StoryTests is Test {
         _mToken.setBalanceOf(_bob, 100_000000);
 
         vm.prank(_bob);
-        _wrappedMToken.wrap(_bob, 100_000000);
+        _swapFacility.swapInM(address(_wrappedMToken), 100_000000, _bob);
 
         // Assert Bob (Earner)
         assertEq(_wrappedMToken.balanceOf(_bob), 100_000000);
@@ -132,7 +135,7 @@ contract StoryTests is Test {
         _mToken.setBalanceOf(_dave, 100_000000);
 
         vm.prank(_dave);
-        _wrappedMToken.wrap(_dave, 100_000000);
+        _swapFacility.swapInM(address(_wrappedMToken), 100_000000, _dave);
 
         // Assert Dave (Non-Earner)
         assertEq(_wrappedMToken.balanceOf(_dave), 100_000000);
@@ -307,7 +310,10 @@ contract StoryTests is Test {
         assertEq(_wrappedMToken.excess(), 599_999996);
 
         vm.prank(_alice);
-        _wrappedMToken.unwrap(_alice, 266_666664);
+        _wrappedMToken.approve(address(_swapFacility), 266_666664);
+
+        vm.prank(_alice);
+        _swapFacility.swapOutM(address(_wrappedMToken), 266_666664, _alice);
 
         // Assert Alice (Non-Earner)
         assertEq(_wrappedMToken.balanceOf(_alice), 0);
@@ -321,7 +327,10 @@ contract StoryTests is Test {
         assertEq(_wrappedMToken.excess(), 599_999996);
 
         vm.prank(_bob);
-        _wrappedMToken.unwrap(_bob, 150_000000);
+        _wrappedMToken.approve(address(_swapFacility), 150_000000);
+
+        vm.prank(_bob);
+        _swapFacility.swapOutM(address(_wrappedMToken), 150_000000, _bob);
 
         // Assert Bob (Earner)
         assertEq(_wrappedMToken.balanceOf(_bob), 0);
@@ -335,7 +344,10 @@ contract StoryTests is Test {
         assertEq(_wrappedMToken.excess(), 599_999996);
 
         vm.prank(_carol);
-        _wrappedMToken.unwrap(_carol, 200_000000);
+        _wrappedMToken.approve(address(_swapFacility), 200_000000);
+
+        vm.prank(_carol);
+        _swapFacility.swapOutM(address(_wrappedMToken), 200_000000, _carol);
 
         // Assert Carol (Earner)
         assertEq(_wrappedMToken.balanceOf(_carol), 0);
@@ -349,7 +361,10 @@ contract StoryTests is Test {
         assertEq(_wrappedMToken.excess(), 599_999996);
 
         vm.prank(_dave);
-        _wrappedMToken.unwrap(_dave, 50_000000);
+        _wrappedMToken.approve(address(_swapFacility), 50_000000);
+
+        vm.prank(_dave);
+        _swapFacility.swapOutM(address(_wrappedMToken), 50_000000, _dave);
 
         // Assert Dave (Non-Earner)
         assertEq(_wrappedMToken.balanceOf(_dave), 0);
@@ -377,7 +392,7 @@ contract StoryTests is Test {
 
         for (uint256 i_; i_ < 100; ++i_) {
             vm.prank(_alice);
-            _wrappedMToken.wrap(_alice, 9);
+            _swapFacility.swapInM(address(_wrappedMToken), 9, _alice);
 
             assertLe(
                 int256(_wrappedMToken.balanceOf(_alice)) + int256(_wrappedMToken.excess()),
@@ -398,8 +413,12 @@ contract StoryTests is Test {
         );
 
         uint256 bobBalance_ = _wrappedMToken.balanceOf(_bob);
+
         vm.prank(_bob);
-        _wrappedMToken.unwrap(_bob, bobBalance_);
+        _wrappedMToken.approve(address(_swapFacility), bobBalance_);
+
+        vm.prank(_bob);
+        _swapFacility.swapOutM(address(_wrappedMToken), bobBalance_, _bob);
     }
 
     function test_dustWrapping() external {
@@ -416,7 +435,7 @@ contract StoryTests is Test {
 
         for (uint256 i_; i_ < 100; ++i_) {
             vm.prank(_alice);
-            _wrappedMToken.wrap(_alice, 1);
+            _swapFacility.swapInM(address(_wrappedMToken), 1, _alice);
 
             assertLe(
                 int256(_wrappedMToken.balanceOf(_alice)) + int256(_wrappedMToken.excess()),

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -83,7 +83,7 @@ contract WrappedMTokenTests is Test {
         assertEq(_wrappedMToken.registrar(), address(_registrar));
         assertEq(_wrappedMToken.excessDestination(), _excessDestination);
         assertEq(_wrappedMToken.swapFacility(), address(_swapFacility));
-        assertEq(_wrappedMToken.name(), "M (Wrapped) by M^0");
+        assertEq(_wrappedMToken.name(), "M (Wrapped) by M0");
         assertEq(_wrappedMToken.symbol(), "wM");
         assertEq(_wrappedMToken.decimals(), 6);
         assertEq(_wrappedMToken.implementation(), address(_implementation));

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -15,7 +15,7 @@ import { Test } from "../../lib/forge-std/src/Test.sol";
 
 import { IWrappedMToken } from "../../src/interfaces/IWrappedMToken.sol";
 
-import { MockEarnerManager, MockM, MockRegistrar } from "../utils/Mocks.sol";
+import { MockEarnerManager, MockM, MockRegistrar, MockSwapFacility } from "../utils/Mocks.sol";
 import { WrappedMTokenHarness } from "../utils/WrappedMTokenHarness.sol";
 
 // TODO: All operations involving earners should include demonstration of accrued yield being added to their balance.
@@ -43,6 +43,7 @@ contract WrappedMTokenTests is Test {
     MockEarnerManager internal _earnerManager;
     MockM internal _mToken;
     MockRegistrar internal _registrar;
+    MockSwapFacility internal _swapFacility;
     WrappedMTokenHarness internal _implementation;
     WrappedMTokenHarness internal _wrappedMToken;
 
@@ -53,11 +54,14 @@ contract WrappedMTokenTests is Test {
 
         _earnerManager = new MockEarnerManager();
 
+        _swapFacility = new MockSwapFacility(address(_mToken));
+
         _implementation = new WrappedMTokenHarness(
             address(_mToken),
             address(_registrar),
             address(_earnerManager),
             _excessDestination,
+            address(_swapFacility),
             _migrationAdmin
         );
 
@@ -78,6 +82,7 @@ contract WrappedMTokenTests is Test {
         assertEq(_wrappedMToken.mToken(), address(_mToken));
         assertEq(_wrappedMToken.registrar(), address(_registrar));
         assertEq(_wrappedMToken.excessDestination(), _excessDestination);
+        assertEq(_wrappedMToken.swapFacility(), address(_swapFacility));
         assertEq(_wrappedMToken.name(), "M (Wrapped) by M^0");
         assertEq(_wrappedMToken.symbol(), "wM");
         assertEq(_wrappedMToken.decimals(), 6);
@@ -88,17 +93,17 @@ contract WrappedMTokenTests is Test {
 
     function test_constructor_zeroMToken() external {
         vm.expectRevert(IWrappedMToken.ZeroMToken.selector);
-        new WrappedMTokenHarness(address(0), address(0), address(0), address(0), address(0));
+        new WrappedMTokenHarness(address(0), address(0), address(0), address(0), address(0), address(0));
     }
 
     function test_constructor_zeroRegistrar() external {
         vm.expectRevert(IWrappedMToken.ZeroRegistrar.selector);
-        new WrappedMTokenHarness(address(_mToken), address(0), address(0), address(0), address(0));
+        new WrappedMTokenHarness(address(_mToken), address(0), address(0), address(0), address(0), address(0));
     }
 
     function test_constructor_zeroEarnerManager() external {
         vm.expectRevert(IWrappedMToken.ZeroEarnerManager.selector);
-        new WrappedMTokenHarness(address(_mToken), address(_registrar), address(0), address(0), address(0));
+        new WrappedMTokenHarness(address(_mToken), address(_registrar), address(0), address(0), address(0), address(0));
     }
 
     function test_constructor_zeroExcessDestination() external {
@@ -107,6 +112,19 @@ contract WrappedMTokenTests is Test {
             address(_mToken),
             address(_registrar),
             address(_earnerManager),
+            address(0),
+            address(0),
+            address(0)
+        );
+    }
+
+    function test_constructor_zeroSwapFacility() external {
+        vm.expectRevert(IWrappedMToken.ZeroSwapFacility.selector);
+        new WrappedMTokenHarness(
+            address(_mToken),
+            address(_registrar),
+            address(_earnerManager),
+            _excessDestination,
             address(0),
             address(0)
         );
@@ -119,6 +137,7 @@ contract WrappedMTokenTests is Test {
             address(_registrar),
             address(_earnerManager),
             _excessDestination,
+            address(_swapFacility),
             address(0)
         );
     }
@@ -132,7 +151,8 @@ contract WrappedMTokenTests is Test {
     function test_internalWrap_insufficientAmount() external {
         vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, 0));
 
-        _wrappedMToken.internalWrap(_alice, _alice, 0);
+        vm.prank(_alice);
+        _wrappedMToken.internalWrap(_alice, 0);
     }
 
     function test_internalWrap_invalidRecipient() external {
@@ -140,7 +160,8 @@ contract WrappedMTokenTests is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InvalidRecipient.selector, address(0)));
 
-        _wrappedMToken.internalWrap(_alice, address(0), 1_000);
+        vm.prank(_alice);
+        _wrappedMToken.internalWrap(address(0), 1_000);
     }
 
     function test_internalWrap_toNonEarner() external {
@@ -161,7 +182,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(address(0), _alice, 1_000);
 
-        _wrappedMToken.internalWrap(_alice, _alice, 1_000);
+        vm.prank(_alice);
+        _wrappedMToken.internalWrap(_alice, 1_000);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 0);
         assertEq(_wrappedMToken.balanceOf(_alice), 2_000);
@@ -194,7 +216,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(address(0), _alice, 999);
 
-        _wrappedMToken.internalWrap(_alice, _alice, 999);
+        vm.prank(_alice);
+        _wrappedMToken.internalWrap(_alice, 999);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 1_000 + 908);
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000 + 999);
@@ -207,7 +230,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(address(0), _alice, 1);
 
-        _wrappedMToken.internalWrap(_alice, _alice, 1);
+        vm.prank(_alice);
+        _wrappedMToken.internalWrap(_alice, 1);
 
         // No change due to principal round down on wrap.
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 1_000 + 908 + 0);
@@ -221,7 +245,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(address(0), _alice, 2);
 
-        _wrappedMToken.internalWrap(_alice, _alice, 2);
+        vm.prank(_alice);
+        _wrappedMToken.internalWrap(_alice, 2);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 1_000 + 908 + 0 + 1);
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000 + 999 + 1 + 2);
@@ -233,11 +258,19 @@ contract WrappedMTokenTests is Test {
     }
 
     /* ============ wrap ============ */
+    function test_wrap_notSwapFacility() external {
+        vm.expectRevert(IWrappedMToken.NotSwapFacility.selector);
+
+        vm.prank(_alice);
+        _wrappedMToken.wrap(_alice, 1_000);
+    }
+
     function test_wrap_invalidAmount() external {
+        _mToken.setBalanceOf(_alice, uint256(type(uint240).max) + 1);
         vm.expectRevert(UIntMath.InvalidUInt240.selector);
 
         vm.prank(_alice);
-        _wrappedMToken.wrap(_alice, uint256(type(uint240).max) + 1);
+        _swapFacility.swapInM(address(_wrappedMToken), uint256(type(uint240).max) + 1, _alice);
     }
 
     function testFuzz_wrap(
@@ -278,7 +311,7 @@ contract WrappedMTokenTests is Test {
         }
 
         vm.startPrank(_alice);
-        _wrappedMToken.wrap(_alice, wrapAmount_);
+        _swapFacility.swapInM(address(_wrappedMToken), wrapAmount_, _alice);
 
         if (wrapAmount_ == 0) return;
 
@@ -299,137 +332,23 @@ contract WrappedMTokenTests is Test {
         vm.expectRevert(UIntMath.InvalidUInt240.selector);
 
         vm.prank(_alice);
-        _wrappedMToken.wrap(_alice, uint256(type(uint240).max) + 1);
-    }
-
-    /* ============ wrapWithPermit vrs ============ */
-    function test_wrapWithPermit_vrs_invalidAmount() external {
-        vm.expectRevert(UIntMath.InvalidUInt240.selector);
-
-        vm.prank(_alice);
-        _wrappedMToken.wrapWithPermit(_alice, uint256(type(uint240).max) + 1, 0, 0, bytes32(0), bytes32(0));
-    }
-
-    function testFuzz_wrapWithPermit_vrs(
-        bool earningEnabled_,
-        bool accountEarning_,
-        uint240 balanceWithYield_,
-        uint240 balance_,
-        uint240 wrapAmount_,
-        uint128 currentMIndex_,
-        uint128 enableMIndex_,
-        uint128 disableIndex_
-    ) external {
-        (currentMIndex_, enableMIndex_, disableIndex_) = _getFuzzedIndices(
-            currentMIndex_,
-            enableMIndex_,
-            disableIndex_
-        );
-
-        _setupIndexes(earningEnabled_, currentMIndex_, enableMIndex_, disableIndex_);
-
-        (balanceWithYield_, balance_) = _getFuzzedBalances(
-            balanceWithYield_,
-            balance_,
-            _getMaxAmount(_wrappedMToken.currentIndex())
-        );
-
-        _setupAccount(_alice, accountEarning_, balanceWithYield_, balance_);
-
-        wrapAmount_ = uint240(bound(wrapAmount_, 0, _getMaxAmount(_wrappedMToken.currentIndex()) - balanceWithYield_));
-
-        _mToken.setBalanceOf(_alice, wrapAmount_);
-
-        if (wrapAmount_ == 0) {
-            vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, (0)));
-        } else {
-            vm.expectEmit();
-            emit IERC20.Transfer(address(0), _alice, wrapAmount_);
-        }
-
-        vm.startPrank(_alice);
-        _wrappedMToken.wrapWithPermit(_alice, wrapAmount_, 0, 0, bytes32(0), bytes32(0));
-
-        if (wrapAmount_ == 0) return;
-
-        assertEq(_wrappedMToken.balanceOf(_alice), balance_ + wrapAmount_);
-
-        assertEq(
-            accountEarning_ ? _wrappedMToken.totalEarningSupply() : _wrappedMToken.totalNonEarningSupply(),
-            _wrappedMToken.balanceOf(_alice)
-        );
-    }
-
-    /* ============ wrapWithPermit signature ============ */
-    function test_wrapWithPermit_signature_invalidAmount() external {
-        vm.expectRevert(UIntMath.InvalidUInt240.selector);
-
-        vm.prank(_alice);
-        _wrappedMToken.wrapWithPermit(_alice, uint256(type(uint240).max) + 1, 0, hex"");
-    }
-
-    function testFuzz_wrapWithPermit_signature(
-        bool earningEnabled_,
-        bool accountEarning_,
-        uint240 balanceWithYield_,
-        uint240 balance_,
-        uint240 wrapAmount_,
-        uint128 currentMIndex_,
-        uint128 enableMIndex_,
-        uint128 disableIndex_
-    ) external {
-        (currentMIndex_, enableMIndex_, disableIndex_) = _getFuzzedIndices(
-            currentMIndex_,
-            enableMIndex_,
-            disableIndex_
-        );
-
-        _setupIndexes(earningEnabled_, currentMIndex_, enableMIndex_, disableIndex_);
-
-        (balanceWithYield_, balance_) = _getFuzzedBalances(
-            balanceWithYield_,
-            balance_,
-            _getMaxAmount(_wrappedMToken.currentIndex())
-        );
-
-        _setupAccount(_alice, accountEarning_, balanceWithYield_, balance_);
-
-        wrapAmount_ = uint240(bound(wrapAmount_, 0, _getMaxAmount(_wrappedMToken.currentIndex()) - balanceWithYield_));
-
-        _mToken.setBalanceOf(_alice, wrapAmount_);
-
-        if (wrapAmount_ == 0) {
-            vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, (0)));
-        } else {
-            vm.expectEmit();
-            emit IERC20.Transfer(address(0), _alice, wrapAmount_);
-        }
-
-        vm.startPrank(_alice);
-        _wrappedMToken.wrapWithPermit(_alice, wrapAmount_, 0, hex"");
-
-        if (wrapAmount_ == 0) return;
-
-        assertEq(_wrappedMToken.balanceOf(_alice), balance_ + wrapAmount_);
-
-        assertEq(
-            accountEarning_ ? _wrappedMToken.totalEarningSupply() : _wrappedMToken.totalNonEarningSupply(),
-            _wrappedMToken.balanceOf(_alice)
-        );
+        _swapFacility.swapInM(address(_wrappedMToken), uint256(type(uint240).max) + 1, _alice);
     }
 
     /* ============ _unwrap ============ */
     function test_internalUnwrap_insufficientAmount() external {
         vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, 0));
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 0);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(0);
     }
 
     function test_internalUnwrap_insufficientBalance_fromNonEarner() external {
         _wrappedMToken.setAccountOf(_alice, 999);
 
         vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.InsufficientBalance.selector, _alice, 999, 1_000));
-        _wrappedMToken.internalUnwrap(_alice, _alice, 1_000);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(1_000);
     }
 
     function test_internalUnwrap_insufficientBalance_fromEarner() external {
@@ -439,7 +358,8 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setAccountOf(_alice, 999, 909, false, false);
 
         vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.InsufficientBalance.selector, _alice, 999, 1_000));
-        _wrappedMToken.internalUnwrap(_alice, _alice, 1_000);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(1_000);
     }
 
     function test_internalUnwrap_fromNonEarner() external {
@@ -464,7 +384,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(_alice, address(0), 1);
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 1);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(1);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 0);
         assertEq(_wrappedMToken.balanceOf(_alice), 999);
@@ -477,7 +398,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(_alice, address(0), 499);
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 499);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(499);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 0);
         assertEq(_wrappedMToken.balanceOf(_alice), 500);
@@ -490,7 +412,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(_alice, address(0), 500);
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 500);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(500);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 0);
         assertEq(_wrappedMToken.balanceOf(_alice), 0);
@@ -524,7 +447,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(_alice, address(0), 1);
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 1);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(1);
 
         // Change due to principal round up on unwrap.
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 1_000 - 1);
@@ -538,7 +462,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(_alice, address(0), 499);
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 499);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(499);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 1_000 - 1 - 454);
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000 - 1 - 499);
@@ -551,7 +476,8 @@ contract WrappedMTokenTests is Test {
         vm.expectEmit();
         emit IERC20.Transfer(_alice, address(0), 500);
 
-        _wrappedMToken.internalUnwrap(_alice, _alice, 500);
+        vm.prank(_alice);
+        _wrappedMToken.internalUnwrap(500);
 
         assertEq(_wrappedMToken.earningPrincipalOf(_alice), 1_000 - 1 - 454 - 455); // 0
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000 - 1 - 499 - 500); // 0
@@ -563,11 +489,21 @@ contract WrappedMTokenTests is Test {
     }
 
     /* ============ unwrap ============ */
+    function test_unwrap_notSwapFacility() external {
+        vm.expectRevert(IWrappedMToken.NotSwapFacility.selector);
+
+        vm.prank(_alice);
+        _wrappedMToken.unwrap(_alice, 1_000);
+    }
+
     function test_unwrap_invalidAmount() external {
+        vm.prank(_alice);
+        _wrappedMToken.approve(address(_swapFacility), uint256(type(uint240).max) + 1);
+
         vm.expectRevert(UIntMath.InvalidUInt240.selector);
 
         vm.prank(_alice);
-        _wrappedMToken.unwrap(_alice, uint256(type(uint240).max) + 1);
+        _swapFacility.swapOutM(address(_wrappedMToken), uint256(type(uint240).max) + 1, _alice);
     }
 
     function testFuzz_unwrap(
@@ -600,6 +536,9 @@ contract WrappedMTokenTests is Test {
 
         unwrapAmount_ = uint240(bound(unwrapAmount_, 0, (11 * balance_) / 10));
 
+        vm.startPrank(_alice);
+        _wrappedMToken.approve(address(_swapFacility), unwrapAmount_);
+
         if (unwrapAmount_ == 0) {
             vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InsufficientAmount.selector, (0)));
         } else if (unwrapAmount_ > balance_) {
@@ -608,11 +547,11 @@ contract WrappedMTokenTests is Test {
             );
         } else {
             vm.expectEmit();
-            emit IERC20.Transfer(_alice, address(0), unwrapAmount_);
+            emit IERC20.Transfer(address(_swapFacility), address(0), unwrapAmount_);
         }
 
         vm.startPrank(_alice);
-        _wrappedMToken.unwrap(_alice, unwrapAmount_);
+        _swapFacility.swapOutM(address(_wrappedMToken), unwrapAmount_, _alice);
 
         if ((unwrapAmount_ == 0) || (unwrapAmount_ > balance_)) return;
 

--- a/test/utils/Mocks.sol
+++ b/test/utils/Mocks.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.26;
 
+import { IERC20 } from "../../lib/common/src/interfaces/IERC20.sol";
+
 contract MockM {
     uint128 public currentIndex;
 
@@ -64,6 +66,10 @@ contract MockM {
     function stopEarning() external {
         isEarning[msg.sender] = false;
     }
+
+    function approve(address spender_, uint256 amount_) external returns (bool success_) {
+        return true;
+    }
 }
 
 contract MockRegistrar {
@@ -97,5 +103,34 @@ contract MockEarnerManager {
         EarnerDetails storage earnerDetails_ = _earnerDetails[account_];
 
         return (earnerDetails_.status, earnerDetails_.feeRate, earnerDetails_.admin);
+    }
+}
+
+interface IMExtension {
+    function wrap(address recipient, uint256 amount) external;
+    function unwrap(address recipient, uint256 amount) external;
+}
+
+contract MockSwapFacility {
+    address public immutable mToken;
+
+    constructor(address mToken_) {
+        mToken = mToken_;
+    }
+
+    function swapInM(address extensionOut, uint256 amount, address recipient) external {
+        IERC20(mToken).transferFrom(msg.sender, address(this), amount);
+        IERC20(mToken).approve(extensionOut, amount);
+        IMExtension(extensionOut).wrap(recipient, amount);
+    }
+
+    function swapOutM(address extensionIn, uint256 amount, address recipient) external {
+        IERC20(extensionIn).transferFrom(msg.sender, address(this), amount);
+
+        uint256 balanceBefore = IERC20(mToken).balanceOf(address(this));
+        IMExtension(extensionIn).unwrap(address(this), amount);
+
+        amount = IERC20(mToken).balanceOf(address(this)) - balanceBefore;
+        IERC20(mToken).transfer(recipient, amount);
     }
 }

--- a/test/utils/WrappedMTokenHarness.sol
+++ b/test/utils/WrappedMTokenHarness.sol
@@ -10,15 +10,16 @@ contract WrappedMTokenHarness is WrappedMToken {
         address registrar_,
         address earnerManager_,
         address excessDestination_,
+        address swapFacility_,
         address migrationAdmin_
-    ) WrappedMToken(mToken_, registrar_, earnerManager_, excessDestination_, migrationAdmin_) {}
+    ) WrappedMToken(mToken_, registrar_, earnerManager_, excessDestination_, swapFacility_, migrationAdmin_) {}
 
-    function internalWrap(address account_, address recipient_, uint240 amount_) external {
-        _wrap(account_, recipient_, amount_);
+    function internalWrap(address recipient_, uint240 amount_) external {
+        _wrap(recipient_, amount_);
     }
 
-    function internalUnwrap(address account_, address recipient_, uint240 amount_) external {
-        _unwrap(account_, recipient_, amount_);
+    function internalUnwrap(uint240 amount_) external {
+        _unwrap(amount_);
     }
 
     function setIsEarningOf(address account_, bool isEarning_) external {


### PR DESCRIPTION
Proposed changes: 
 - add `SwapFacility` support
 - remove `wrapWithPermit` as it will be replaced with SwapFacility.swapInMWithPermit
 
 Notes:
  - integration tests needs to be updated to use `SwapFacility` contract after it's deployed
  - `unwrap` transfers M to `msg.sender` (`SwapFacility`) rather than recipient to be consistent with `MExtension` contract 