### PR TITLE
fix(WrappedM): fix frozen check inconsistencies

### DIFF
--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -703,6 +703,9 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
      */
     function _unwrap(address account_, uint240 amount_) internal {
         _requireNotPaused();
+
+        // NOTE: No recipient frozen check here. The final recipient receives $M (not Wrapped $M)
+        //       directly from SwapFacility, so a Wrapped $M frozen guard would have no effect.
         _revertIfFrozen(account_);
 
         // NOTE: Always burn from SwapFacility as it is the only contract that can call this function.

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -722,6 +722,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
      */
     function _startEarningFor(address account_, uint128 currentIndex_) internal {
         _requireNotPaused();
+        _revertIfFrozen(account_);
         _revertIfNotApprovedEarner(account_);
 
         Account storage accountInfo_ = _accounts[account_];

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -244,19 +244,20 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
         _revertIfFrozen(account_);
         _revertIfApprovedEarner(account_);
 
-        _stopEarningFor(account_, currentIndex());
+        _stopEarningFor(account_, currentIndex(), paused());
     }
 
     /// @inheritdoc IWrappedMToken
     function stopEarningFor(address[] calldata accounts_) external {
         uint128 currentIndex_ = currentIndex();
+        bool skipTransfer_ = paused();
         FreezableStorageStruct storage $ = _getFreezableStorageLocation();
 
         for (uint256 i; i < accounts_.length; ++i) {
             _revertIfFrozen($, accounts_[i]);
             _revertIfApprovedEarner(accounts_[i]);
 
-            _stopEarningFor(accounts_[i], currentIndex_);
+            _stopEarningFor(accounts_[i], currentIndex_, skipTransfer_);
         }
     }
 
@@ -752,13 +753,14 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
      * @dev   Stops earning for `account` given some current index.
      * @param account_      The account to stop earning for.
      * @param currentIndex_ The current index.
+     * @param skipTransfer_ Whether to skip routing the claimed yield to a non-self claim recipient.
      */
-    function _stopEarningFor(address account_, uint128 currentIndex_) internal {
+    function _stopEarningFor(address account_, uint128 currentIndex_, bool skipTransfer_) internal {
         Account storage accountInfo_ = _accounts[account_];
 
         if (!accountInfo_.isEarning) return;
 
-        _claim(account_, currentIndex_, paused());
+        _claim(account_, currentIndex_, skipTransfer_);
 
         uint240 balance_ = accountInfo_.balance;
         uint112 earningPrincipal_ = accountInfo_.earningPrincipal;
@@ -777,10 +779,12 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
 
     /**
      * @dev   Hook called before freezing an account. Claims accrued yield and stops earning.
+     *        Routing to a claim recipient is skipped so freezing never reverts on a frozen
+     *        recipient and the yield stays on the frozen account, seizable via `forceTransfer`.
      * @param account_ The account about to be frozen.
      */
     function _beforeFreeze(address account_) internal override {
-        _stopEarningFor(account_, currentIndex());
+        _stopEarningFor(account_, currentIndex(), true);
 
         super._beforeFreeze(account_);
     }

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -1343,6 +1343,19 @@ contract WrappedMTokenTests is BaseUnitTest {
         _wrappedMToken.startEarningFor(_alice);
     }
 
+    function test_startEarningFor_frozenAccount() external {
+        _mToken.setCurrentIndex(1_100000000000);
+        _wrappedMToken.setEnableMIndex(1_100000000000);
+
+        _registrar.setListContains(_EARNERS_LIST_NAME, _alice, true);
+
+        vm.prank(_freezeManager);
+        _wrappedMToken.freeze(_alice);
+
+        vm.expectRevert(abi.encodeWithSelector(IFreezable.AccountFrozen.selector, _alice));
+        _wrappedMToken.startEarningFor(_alice);
+    }
+
     function test_startEarning_overflow() external {
         _mToken.setCurrentIndex(1_100000000000);
         _wrappedMToken.setEnableMIndex(1_100000000000);
@@ -1453,6 +1466,24 @@ contract WrappedMTokenTests is BaseUnitTest {
         accounts_[1] = _bob;
 
         vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.NotApprovedEarner.selector, _bob));
+        _wrappedMToken.startEarningFor(accounts_);
+    }
+
+    function test_startEarningFor_batch_frozenAccount() external {
+        _mToken.setCurrentIndex(1_210000000000);
+        _wrappedMToken.setEnableMIndex(1_100000000000);
+
+        _registrar.setListContains(_EARNERS_LIST_NAME, _alice, true);
+        _registrar.setListContains(_EARNERS_LIST_NAME, _bob, true);
+
+        vm.prank(_freezeManager);
+        _wrappedMToken.freeze(_bob);
+
+        address[] memory accounts_ = new address[](2);
+        accounts_[0] = _alice;
+        accounts_[1] = _bob;
+
+        vm.expectRevert(abi.encodeWithSelector(IFreezable.AccountFrozen.selector, _bob));
         _wrappedMToken.startEarningFor(accounts_);
     }
 
@@ -1832,6 +1863,43 @@ contract WrappedMTokenTests is BaseUnitTest {
 
         vm.prank(_forcedTransferManager);
         _wrappedMToken.forceTransfer(_alice, _bob, 500);
+    }
+
+    function test_forceTransfer_frozenEarnerCannotBeReEnabled() external {
+        // Regression: a frozen account must not be re-enabled as an earner, otherwise
+        // `forceTransfer` would run `_subtractNonEarningAmount` on an earning account and
+        // corrupt supply accounting.
+        _mToken.setCurrentIndex(1_210000000000);
+        _wrappedMToken.setEnableMIndex(1_100000000000);
+
+        _wrappedMToken.setTotalEarningPrincipal(1_000);
+        _wrappedMToken.setTotalEarningSupply(1_000);
+
+        _wrappedMToken.setAccountOf(_alice, 1_000, 1_000, false);
+
+        // `_alice` remains an approved earner even after being frozen.
+        _registrar.setListContains(_EARNERS_LIST_NAME, _alice, true);
+
+        vm.prank(_freezeManager);
+        _wrappedMToken.freeze(_alice);
+
+        // Freezing claimed yield (100) and stopped earning, moving the balance to non-earning.
+        assertEq(_wrappedMToken.isEarning(_alice), false);
+        assertEq(_wrappedMToken.totalEarningSupply(), 0);
+        assertEq(_wrappedMToken.totalNonEarningSupply(), 1_100);
+
+        // Re-enabling earning on the still-frozen account must revert.
+        vm.expectRevert(abi.encodeWithSelector(IFreezable.AccountFrozen.selector, _alice));
+        _wrappedMToken.startEarningFor(_alice);
+
+        // The account stays non-earning, so `forceTransfer` keeps accounting correct.
+        vm.prank(_forcedTransferManager);
+        _wrappedMToken.forceTransfer(_alice, _bob, 500);
+
+        assertEq(_wrappedMToken.balanceOf(_alice), 600);
+        assertEq(_wrappedMToken.balanceOf(_bob), 500);
+        assertEq(_wrappedMToken.totalEarningSupply(), 0);
+        assertEq(_wrappedMToken.totalNonEarningSupply(), 1_100);
     }
 
     function test_forceTransfer_invalidRecipient() external {

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -1756,6 +1756,10 @@ contract WrappedMTokenTests is BaseUnitTest {
     }
 
     function test_freeze_skipsClaimRecipientRouting() external {
+        // `_beforeFreeze` claims with skipTransfer=true, so the freeze keeps the yield on the
+        // account being frozen instead of routing it to the claim recipient. This both keeps
+        // the full balance seizable via `forceTransfer` and ensures freezing is never blocked
+        // by a frozen claim recipient (which would otherwise revert the routing transfer).
         _mToken.setCurrentIndex(1_210000000000);
         _wrappedMToken.setEnableMIndex(1_100000000000);
 
@@ -1769,10 +1773,6 @@ contract WrappedMTokenTests is BaseUnitTest {
 
         vm.prank(_freezeManager);
         _wrappedMToken.freeze(_bob);
-
-        // Pause the contract so skipTransfer=true in _beforeFreeze -> _stopEarningFor -> _claim.
-        vm.prank(_pauser);
-        _wrappedMToken.pause();
 
         vm.expectEmit();
         emit IWrappedMToken.Claimed(_alice, _bob, 100);
@@ -1789,8 +1789,8 @@ contract WrappedMTokenTests is BaseUnitTest {
         vm.prank(_freezeManager);
         _wrappedMToken.freeze(_alice);
 
-        assertEq(_wrappedMToken.balanceOf(_alice), 1_100);
-        assertEq(_wrappedMToken.balanceOf(_bob), 0); // yield not routed (paused)
+        assertEq(_wrappedMToken.balanceOf(_alice), 1_100); // yield retained on frozen account
+        assertEq(_wrappedMToken.balanceOf(_bob), 0); // not routed to claim recipient
         assertEq(_wrappedMToken.isEarning(_alice), false);
         assertTrue(_wrappedMToken.isFrozen(_alice));
     }


### PR DESCRIPTION
[fix(WrappedM): revert startEarningFor for frozen accounts](https://github.com/m0-foundation/wrapped-m-token/commit/1899b0b8b3a51f32ee3dd0e1f41b316ccabd086c)

A frozen account is stopped from earning via `_beforeFreeze`, but `startEarningFor` had no frozen check, so anyone could re-enable earning on a still-frozen account. 
This breaks the invariant that `_forceTransfer` relies on (frozen => non-earning): `forceTransfer` would then run `_subtractNonEarningAmount` on an earning account, underflowing `totalNonEarningSupply` and leaving `totalEarningSupply` stale.

Add `_revertIfFrozen` in the shared `_startEarningFor` so both the single and batch overloads are covered.

[fix(WrappedM): skip claim routing in freeze hook to avoid revert on frozen recipient](https://github.com/m0-foundation/wrapped-m-token/commit/6cd9e60689911ce0663e700b0edbfd56ec4bf0c3)

Freezing an account claims its accrued yield via `_beforeFreeze` -> `_stopEarningFor` -> `_claim`. 
Since `_stopEarningFor` claimed with `skipTransfer=paused()`, routing yield to a frozen claim recipient reverted the inner `_transfer`, so an account whose claim recipient was frozen could not be frozen while the contract was unpaused.

Thread an explicit `skipTransfer` flag through `_stopEarningFor` and have `_beforeFreeze` pass `true`, mirroring PYUSDX: the freeze hook always skips `claimRecipient` routing, so the yield materializes on the (now frozen) account and stays seizable via `forceTransfer`. 
Public `claimFor` and `stopEarningFor` keep routing to the claim recipient and still revert if it is frozen.

[docs(WrappedM): explain absence of recipient frozen check in _unwrap](https://github.com/m0-foundation/wrapped-m-token/commit/69cff6ef3a3b8b081fe2382986822a51e7ea254f)

Document why `_unwrap`, unlike `_wrap`, has no recipient frozen check: the final recipient receives $M (not Wrapped $M) directly from SwapFacility, so a Wrapped $M frozen guard would be meaningless. 