### PR TITLE
fix(WrappedM): address internal review findings

### DIFF
--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -56,9 +56,6 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
     /* ============ Variables ============ */
 
     /// @inheritdoc IWrappedMToken
-    uint16 public constant HUNDRED_PERCENT = 10_000;
-
-    /// @inheritdoc IWrappedMToken
     bytes32 public constant EARNERS_LIST_IGNORED_KEY = "earners_list_ignored";
 
     /// @inheritdoc IWrappedMToken
@@ -119,6 +116,7 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
     /* ============ Constructor ============ */
 
     /**
+     * @custom:oz-upgrades-unsafe-allow constructor
      * @dev   Constructs the contract given an M Token address and migration admin.
      *        Note that a proxy will not need to initialize since there are no mutable storage values affected.
      * @param mToken_         The address of an M Token.
@@ -132,6 +130,8 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
         address swapFacility_,
         address migrationAdmin_
     ) ERC20Extended("M (Wrapped) by M0", "wM", 6) {
+        _disableInitializers();
+
         if ((mToken = mToken_) == address(0)) revert ZeroMToken();
         if ((registrar = registrar_) == address(0)) revert ZeroRegistrar();
         if ((swapFacility = swapFacility_) == address(0)) revert ZeroSwapFacility();

--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -97,7 +97,7 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
     /// @notice Emitted in constructor if default admin is 0x0.
     error ZeroAdmin();
 
-    /// @notice Emitted in `initialize` if Earner Manager is 0x0.
+    /// @notice Emitted in `initialize` if Excess Manager is 0x0.
     error ZeroExcessManager();
 
     /// @notice Emitted in `initialize` and `setExcessDestination` if Excess Destination is 0x0.
@@ -156,25 +156,25 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
     function disableEarning() external;
 
     /**
-     * @notice Starts earning for `account` if allowed by the Earner Manager.
+     * @notice Starts earning for `account` if allowed by the Registrar.
      * @param  account The account to start earning for.
      */
     function startEarningFor(address account) external;
 
     /**
-     * @notice Starts earning for multiple accounts if individually allowed by the Earner Manager.
+     * @notice Starts earning for multiple accounts if individually allowed by the Registrar.
      * @param  accounts The accounts to start earning for.
      */
     function startEarningFor(address[] calldata accounts) external;
 
     /**
-     * @notice Stops earning for `account` if disallowed by the Earner Manager.
+     * @notice Stops earning for `account` if disallowed by the Registrar.
      * @param  account The account to stop earning for.
      */
     function stopEarningFor(address account) external;
 
     /**
-     * @notice Stops earning for multiple accounts if individually disallowed by the Earner Manager.
+     * @notice Stops earning for multiple accounts if individually disallowed by the Registrar.
      * @param  accounts The accounts to stop earning for.
      */
     function stopEarningFor(address[] calldata accounts) external;
@@ -202,10 +202,7 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
 
     /* ============ View/Pure Functions ============ */
 
-    /// @notice 100% in basis points.
-    function HUNDRED_PERCENT() external pure returns (uint16 hundredPercent);
-
-    /// @notice The role that can set the excess destination and manage approved earners.
+    /// @notice The role that can set the excess destination.
     function EXCESS_MANAGER_ROLE() external pure returns (bytes32 excessManagerRole);
 
     /// @notice Registrar key holding value of whether the earners list can be ignored or not.


### PR DESCRIPTION
- I-01: call `_disableInitializers()` in constructor to lock down the implementation contract, per OpenZeppelin guidance
- I-02: fix NatSpec typos in `IWrappedMToken` (Earner Manager -> Registrar/ Excess Manager, `EXCESS_MANAGER_ROLE` description)
- I-03: remove unused `HUNDRED_PERCENT` constant and interface declaration