### PR TITLE
fix(WrappedM): address ChainSecurity audit issues

### DIFF
--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -551,13 +551,14 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
             totalEarningSupply += yield_;
         }
 
-        address claimRecipient_ = claimRecipientFor(account_);
+        // When transferring is skipped, the yield stays on `account_`, so it is the effective recipient.
+        address claimRecipient_ = skipTransfer_ ? account_ : claimRecipientFor(account_);
 
         // Emit the appropriate `Claimed` and `Transfer` events, depending on the claim override recipient
         emit Claimed(account_, claimRecipient_, yield_);
         emit Transfer(address(0), account_, yield_);
 
-        if (skipTransfer_ || claimRecipient_ == account_) return yield_;
+        if (claimRecipient_ == account_) return yield_;
 
         _transfer(account_, claimRecipient_, yield_, currentIndex_);
     }

--- a/src/WrappedMToken.sol
+++ b/src/WrappedMToken.sol
@@ -157,6 +157,10 @@ contract WrappedMToken is IWrappedMToken, Migratable, ERC20Extended, Freezable, 
         address excessManager_,
         address excessDestination_
     ) public initializer {
+        __Context_init();
+        __ERC165_init();
+        __AccessControl_init();
+
         if (admin_ == address(0)) revert ZeroAdmin();
         _grantRole(DEFAULT_ADMIN_ROLE, admin_);
 

--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -129,9 +129,9 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
     function wrap(address recipient, uint256 amount) external;
 
     /**
-     * @notice Unwraps `amount` wM from the caller into M for `recipient`.
+     * @notice Unwraps `amount` wM from the caller into M, sending the M to the SwapFacility.
      * @dev    Can only be called by the SwapFacility.
-     * @param  recipient The account receiving the withdrawn M.
+     * @param  recipient Unused. The M is always sent to the SwapFacility, which routes it to the final recipient.
      * @param  amount    The amount of wM burned.
      */
     function unwrap(address recipient, uint256 amount) external;
@@ -149,10 +149,10 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
      */
     function claimExcess() external returns (uint240 claimed);
 
-    /// @notice Enables earning of Wrapped M if allowed by the Registrar and if it has never been done.
+    /// @notice Enables earning of Wrapped M if allowed by the Registrar and not already enabled.
     function enableEarning() external;
 
-    /// @notice Disables earning of Wrapped M if disallowed by the Registrar and if it has never been done.
+    /// @notice Disables earning of Wrapped M if disallowed by the Registrar and not already disabled.
     function disableEarning() external;
 
     /**

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -169,14 +169,7 @@ contract WrappedMTokenTests is BaseUnitTest {
         WrappedMTokenHarness wrappedMToken_ = WrappedMTokenHarness(address(new Proxy(address(_implementation))));
 
         vm.expectRevert(IForcedTransferable.ZeroForcedTransferManager.selector);
-        wrappedMToken_.initialize(
-            _admin,
-            _freezeManager,
-            _pauser,
-            address(0),
-            _excessManager,
-            _excessDestination
-        );
+        wrappedMToken_.initialize(_admin, _freezeManager, _pauser, address(0), _excessManager, _excessDestination);
     }
 
     function test_initialize_zeroExcessManager() external {
@@ -197,14 +190,7 @@ contract WrappedMTokenTests is BaseUnitTest {
         WrappedMTokenHarness wrappedMToken_ = WrappedMTokenHarness(address(new Proxy(address(_implementation))));
 
         vm.expectRevert(IWrappedMToken.ZeroExcessDestination.selector);
-        wrappedMToken_.initialize(
-            _admin,
-            _freezeManager,
-            _pauser,
-            _forcedTransferManager,
-            _excessManager,
-            address(0)
-        );
+        wrappedMToken_.initialize(_admin, _freezeManager, _pauser, _forcedTransferManager, _excessManager, address(0));
     }
 
     /* ============ setExcessDestination ============ */
@@ -1628,6 +1614,38 @@ contract WrappedMTokenTests is BaseUnitTest {
         assertEq(_wrappedMToken.isEarning(_alice), false);
     }
 
+    function test_stopEarningFor_enforcedPause_withClaimRecipient() external {
+        _mToken.setCurrentIndex(1_210000000000);
+        _wrappedMToken.setEnableMIndex(1_100000000000);
+
+        _wrappedMToken.setTotalEarningPrincipal(1_000);
+        _wrappedMToken.setTotalEarningSupply(1_000);
+
+        _wrappedMToken.setAccountOf(_alice, 1_000, 1_000, true);
+        _wrappedMToken.setInternalClaimRecipient(_alice, _bob);
+
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), _bob);
+
+        vm.prank(_pauser);
+        _wrappedMToken.pause();
+
+        // skipTransfer=true: yield stays on `_alice`, so `Claimed` must report `_alice` not `_bob`.
+        vm.expectEmit();
+        emit IWrappedMToken.Claimed(_alice, _alice, 100);
+
+        vm.expectEmit();
+        emit IERC20.Transfer(address(0), _alice, 100);
+
+        vm.expectEmit();
+        emit IWrappedMToken.StoppedEarning(_alice);
+
+        _wrappedMToken.stopEarningFor(_alice);
+
+        assertEq(_wrappedMToken.balanceOf(_alice), 1_100);
+        assertEq(_wrappedMToken.balanceOf(_bob), 0);
+        assertEq(_wrappedMToken.isEarning(_alice), false);
+    }
+
     function test_stopEarningFor_frozenAccount() external {
         _wrappedMToken.setIsEarningOf(_alice, true);
 
@@ -1860,7 +1878,7 @@ contract WrappedMTokenTests is BaseUnitTest {
         _wrappedMToken.freeze(_bob);
 
         vm.expectEmit();
-        emit IWrappedMToken.Claimed(_alice, _bob, 100);
+        emit IWrappedMToken.Claimed(_alice, _alice, 100);
 
         vm.expectEmit();
         emit IERC20.Transfer(address(0), _alice, 100);


### PR DESCRIPTION
Issues:
- 009 - [fix(WrappedM): correct Claimed event recipient when skipTransfer is true](https://github.com/m0-foundation/wrapped-m-token/commit/a6a8eef567762caddea836ca46ac6b42e7ebd0eb)
When `_claim` runs with `skipTransfer_` true (paused stop-earning or freeze), the yield stays on `account_`, but the `Claimed` event reported the configured claim recipient. 
Compute the effective recipient as `account_` when transfer is skipped so the event reflects where the yield actually lands.

- 014 - [docs(WrappedM): correct inaccurate NatSpec on unwrap and earning toggles](https://github.com/m0-foundation/wrapped-m-token/commit/9885e62290f5bedaca0ac82a206c6878edd2c2c4)
  - unwrap: document that `recipient` is unused and M is always sent to the SwapFacility, which routes it to the final recipient.
  - `enableEarning`/`disableEarning`: replace "if it has never been done" with "not already `enabled`/`disabled`", since earning can be toggled multiple times.

- 015 - [chore(WrappedM): call inherited base initializers in initialize()](https://github.com/m0-foundation/wrapped-m-token/commit/96d23fa1325fa3c14a5681d0ee2aa88ef523d2b2)
Invoke `__Context_init`, `__ERC165_init`, and `__AccessControl_init` in the initializer. 
These are no-ops in the current OpenZeppelin version, but calling them prevents silently uninitialized state should a future version add meaningful initialization logic.